### PR TITLE
Remove duplicated code

### DIFF
--- a/talk/owt/sdk/base/objc/OWTLocalStream.mm
+++ b/talk/owt/sdk/base/objc/OWTLocalStream.mm
@@ -122,7 +122,7 @@
   OWTStreamSourceInfo* sourceInfo = [[OWTStreamSourceInfo alloc] init];
   sourceInfo.audio = OWTAudioSourceInfoMic;
   sourceInfo.video = OWTVideoSourceInfoCamera;
-  self = [super initWithMediaStream:stream source:sourceInfo];
+  self = [self initWithMediaStream:stream source:sourceInfo];
   return self;
 }
 - (void)setAttributes:(NSDictionary<NSString*, NSString*>*)attributes {

--- a/talk/owt/sdk/base/objc/OWTLocalStream.mm
+++ b/talk/owt/sdk/base/objc/OWTLocalStream.mm
@@ -123,12 +123,6 @@
   sourceInfo.audio = OWTAudioSourceInfoMic;
   sourceInfo.video = OWTVideoSourceInfoCamera;
   self = [super initWithMediaStream:stream source:sourceInfo];
-  std::shared_ptr<owt::base::LocalStream> nativeStream =
-      std::make_shared<owt::base::LocalStream>(
-          stream.nativeMediaStream,
-          owt::base::StreamSourceInfo(owt::base::AudioSourceInfo::kMic,
-                                      owt::base::VideoSourceInfo::kCamera));
-  [self setNativeStream:nativeStream];
   return self;
 }
 - (void)setAttributes:(NSDictionary<NSString*, NSString*>*)attributes {


### PR DESCRIPTION
`nativeStream`  has been created in designated initializer by calling `self = [super initWithMediaStream:stream source:sourceInfo];`, so it needn't be created again here.