### PR TITLE
Fix retain-cycles

### DIFF
--- a/talk/owt/sdk/conference/objc/ConferenceClientObserverObjcImpl.h
+++ b/talk/owt/sdk/conference/objc/ConferenceClientObserverObjcImpl.h
@@ -31,8 +31,8 @@ class ConferenceClientObserverObjcImpl : public ConferenceClientObserver {
   void AddRemoteStreamToMap(const std::string& id, OWTRemoteStream* stream);
   void TriggerOnStreamRemoved(
       std::shared_ptr<owt::base::RemoteStream> stream);
-  OWTConferenceClient* client_;
-  id<OWTConferenceClientDelegate> delegate_;
+  __weak OWTConferenceClient* client_;
+  __weak id<OWTConferenceClientDelegate> delegate_;
   std::unordered_map<std::string, OWTRemoteStream*> remote_streams_;
   std::mutex remote_streams_mutex_;
   std::unordered_map<std::string, OWTLocalStream*> local_streams_;

--- a/talk/owt/sdk/conference/objc/ConferencePublicationObserverObjcImpl.h
+++ b/talk/owt/sdk/conference/objc/ConferencePublicationObserverObjcImpl.h
@@ -21,8 +21,8 @@ class ConferencePublicationObserverObjcImpl : public owt::base::PublicationObser
   /// Triggered when audio and/or video is unmuted.
   virtual void OnUnmute(owt::base::TrackKind track_kind) override;
  private:
-  OWTConferencePublication* publication_;
-  id<OWTConferencePublicationDelegate> delegate_;
+  __weak OWTConferencePublication* publication_;
+  __weak id<OWTConferencePublicationDelegate> delegate_;
 };
 }  // namespace conference
 }  // namespace owt

--- a/talk/owt/sdk/conference/objc/ConferenceSubscriptionObserverObjcImpl.h
+++ b/talk/owt/sdk/conference/objc/ConferenceSubscriptionObserverObjcImpl.h
@@ -23,8 +23,8 @@ class ConferenceSubscriptionObserverObjcImpl
   /// Triggered when audio and/or video is unmuted.
   virtual void OnUnmute(owt::base::TrackKind track_kind) override;
  private:
-  OWTConferenceSubscription* subscription_;
-  id<OWTConferenceSubscriptionDelegate> delegate_;
+  __weak OWTConferenceSubscription* subscription_;
+  __weak id<OWTConferenceSubscriptionDelegate> delegate_;
 };
 }  // namespace conference
 }  // namespace owt

--- a/talk/owt/sdk/conference/objc/OWTConferenceClient.mm
+++ b/talk/owt/sdk/conference/objc/OWTConferenceClient.mm
@@ -237,18 +237,22 @@ PlayPauseFailureCallback(FailureBlock on_failure,
       });
 }
 - (void)setDelegate:(id<OWTConferenceClientDelegate>)delegate {
-  __weak OWTConferenceClient *weakSelf = self;
-  _observer = std::unique_ptr<
-      owt::conference::ConferenceClientObserverObjcImpl,
-      std::function<void(owt::conference::ConferenceClientObserverObjcImpl*)>>(
-      new owt::conference::ConferenceClientObserverObjcImpl(self, delegate),
-      [=](owt::conference::ConferenceClientObserverObjcImpl* observer) {
-        __strong OWTConferenceClient *strongSelf = weakSelf;
-        if (strongSelf != nil) {
-          strongSelf->_nativeConferenceClient->RemoveObserver(*observer);
-        }
-      });
-  _nativeConferenceClient->AddObserver(*_observer.get());
+  if (delegate != nil) {
+    __weak OWTConferenceClient *weakSelf = self;
+    _observer = std::unique_ptr<
+            owt::conference::ConferenceClientObserverObjcImpl,
+            std::function<void(owt::conference::ConferenceClientObserverObjcImpl*)>>(
+                    new owt::conference::ConferenceClientObserverObjcImpl(self, delegate),
+                    [=](owt::conference::ConferenceClientObserverObjcImpl* observer) {
+                        __strong OWTConferenceClient *strongSelf = weakSelf;
+                        if (strongSelf != nil) {
+                          strongSelf->_nativeConferenceClient->RemoveObserver(*observer);
+                        }
+                    });
+    _nativeConferenceClient->AddObserver(*_observer.get());
+  } else {
+    _observer.reset();
+  }
   _delegate = delegate;
 }
 @end

--- a/talk/owt/sdk/conference/objc/OWTConferenceClient.mm
+++ b/talk/owt/sdk/conference/objc/OWTConferenceClient.mm
@@ -87,6 +87,7 @@
     return;
   }
   const std::string nativeToken = [token UTF8String];
+  __weak OWTConferenceClient *weakSelf = self;
   _nativeConferenceClient->Join(
       nativeToken,
       [=](std::shared_ptr<owt::conference::ConferenceInfo> info) {
@@ -95,7 +96,7 @@
               initWithNativeInfo:info]);
       },
       [=](std::unique_ptr<owt::base::Exception> e) {
-        [self triggerOnFailure:onFailure withException:(std::move(e))];
+        [weakSelf triggerOnFailure:onFailure withException:(std::move(e))];
       });
 }
 - (void)publish:(OWTLocalStream*)stream

--- a/talk/owt/sdk/conference/objc/OWTConferenceClient.mm
+++ b/talk/owt/sdk/conference/objc/OWTConferenceClient.mm
@@ -237,12 +237,16 @@ PlayPauseFailureCallback(FailureBlock on_failure,
       });
 }
 - (void)setDelegate:(id<OWTConferenceClientDelegate>)delegate {
+  __weak OWTConferenceClient *weakSelf = self;
   _observer = std::unique_ptr<
       owt::conference::ConferenceClientObserverObjcImpl,
       std::function<void(owt::conference::ConferenceClientObserverObjcImpl*)>>(
       new owt::conference::ConferenceClientObserverObjcImpl(self, delegate),
-      [&self](owt::conference::ConferenceClientObserverObjcImpl* observer) {
-        self->_nativeConferenceClient->RemoveObserver(*observer);
+      [=](owt::conference::ConferenceClientObserverObjcImpl* observer) {
+        __strong OWTConferenceClient *strongSelf = weakSelf;
+        if (strongSelf != nil) {
+          strongSelf->_nativeConferenceClient->RemoveObserver(*observer);
+        }
       });
   _nativeConferenceClient->AddObserver(*_observer.get());
   _delegate = delegate;

--- a/talk/owt/sdk/conference/objc/OWTConferencePublication.mm
+++ b/talk/owt/sdk/conference/objc/OWTConferencePublication.mm
@@ -100,14 +100,22 @@
   return [NSString stringForStdString:_nativePublication->Id()];
 }
 -(void)setDelegate:(id<OWTConferencePublicationDelegate>)delegate{
-  _observer = std::unique_ptr<
-      owt::conference::ConferencePublicationObserverObjcImpl,
-      std::function<void(owt::conference::ConferencePublicationObserverObjcImpl*)>>(
-      new owt::conference::ConferencePublicationObserverObjcImpl(self, delegate),
-      [&self](owt::conference::ConferencePublicationObserverObjcImpl* observer) {
-        self->_nativePublication->RemoveObserver(*observer);
-      });
-  _nativePublication->AddObserver(*_observer.get());
+  if (delegate != nil) {
+    __weak OWTConferencePublication *weakSelf = self;
+    _observer = std::unique_ptr<
+                owt::conference::ConferencePublicationObserverObjcImpl,
+            std::function<void(owt::conference::ConferencePublicationObserverObjcImpl*)>>(
+                    new owt::conference::ConferencePublicationObserverObjcImpl(self, delegate),
+                            [=](owt::conference::ConferencePublicationObserverObjcImpl* observer) {
+                              __strong OWTConferencePublication *strongSelf = weakSelf;
+                              if (strongSelf) {
+                                strongSelf->_nativePublication->RemoveObserver(*observer);
+                              }
+                            });
+    _nativePublication->AddObserver(*_observer.get());
+  } else {
+    _observer.reset();
+  }
   _delegate = delegate;
 }
 @end

--- a/talk/owt/sdk/conference/objc/OWTConferenceSubscription.mm
+++ b/talk/owt/sdk/conference/objc/OWTConferenceSubscription.mm
@@ -124,14 +124,22 @@
   return [NSString stringForStdString:_nativeSubscription->Id()];
 }
 -(void)setDelegate:(id<OWTConferenceSubscriptionDelegate>)delegate{
-  _observer = std::unique_ptr<
-      owt::conference::ConferenceSubscriptionObserverObjcImpl,
-      std::function<void(owt::conference::ConferenceSubscriptionObserverObjcImpl*)>>(
-      new owt::conference::ConferenceSubscriptionObserverObjcImpl(self, delegate),
-      [&self](owt::conference::ConferenceSubscriptionObserverObjcImpl* observer) {
-        self->_nativeSubscription->RemoveObserver(*observer);
-      });
-  _nativeSubscription->AddObserver(*_observer.get());
+  if (delegate != nil) {
+    __weak OWTConferenceSubscription *weakSelf = self;
+    _observer = std::unique_ptr<
+                owt::conference::ConferenceSubscriptionObserverObjcImpl,
+            std::function<void(owt::conference::ConferenceSubscriptionObserverObjcImpl*)>>(
+                    new owt::conference::ConferenceSubscriptionObserverObjcImpl(self, delegate),
+                            [=](owt::conference::ConferenceSubscriptionObserverObjcImpl* observer) {
+                                __strong OWTConferenceSubscription *strongSelf = weakSelf;
+                                if (strongSelf) {
+                                  strongSelf->_nativeSubscription->RemoveObserver(*observer);
+                                }
+                            });
+    _nativeSubscription->AddObserver(*_observer.get());
+  } else {
+    _observer.reset();
+  }
   _delegate = delegate;
 }
 @end


### PR DESCRIPTION
### 1. Break retain-cycle between OWTConferenceClient and ConferenceSocketSignalingChannel


The retain-cycle looks like this: (-> means retaining)
OWTConferenceClient -> ConferenceClient -> ConferenceSocketSignalingChannel -> OWTConferenceClient


What's the problem? 

Once some one call [client joinWithToken: xxx ], the second lambda (on_failure) which retain self will be retained by ConferenceSocketSignalingChannel finally, but OWTConferenceClient retains the ConferenceSocketSignalingChannel instance, so here is the retain-cycle.

```c++
  _nativeConferenceClient->Join(
      nativeToken,
      [=](std::shared_ptr<owt::conference::ConferenceInfo> info) {
        if (onSuccess != nil)
          onSuccess([[OWTConferenceInfo alloc]
              initWithNativeInfo:info]);
      },

     // here 👇
      [=](std::unique_ptr<owt::base::Exception> e) {
        [self triggerOnFailure:onFailure withException:(std::move(e))];
      });

```

### 2. Break retain-cycle between OWTConferenceClient, OWTConferenceClient’s delegate and ConferenceClientObserverObjcImpl

The retain-cycle looks like this: (-> stands for retaining)
OWTConferenceClient’s delegate  -> OWTConferenceClient -> ConferenceClientObserverObjcImpl -> OWTConferenceClient’s delegate

So what's the problem here ?

Once some one like Object A create a client, and set its delegate to be the A object, althought delegate is weak, but the delegate will be passed to the observer, which is strong retained the delegate, and the observer is retained by the client. so here  is the retain-cycle

```c++
  _observer = std::unique_ptr<
      owt::conference::ConferenceClientObserverObjcImpl,
      std::function<void(owt::conference::ConferenceClientObserverObjcImpl*)>>(
      new owt::conference::ConferenceClientObserverObjcImpl(self, delegate),
      [&self](owt::conference::ConferenceClientObserverObjcImpl* observer) {
        self->_nativeConferenceClient->RemoveObserver(*observer);
      });
```

### 3. OWTConferencePublication and OWTConferenceSubscription have very similar case as OWTConferenceClient.
