### PR TITLE
Remove redundant for-loop which adds users to participants_ twice

### DIFF
--- a/talk/owt/sdk/conference/conferenceclient.cc
+++ b/talk/owt/sdk/conference/conferenceclient.cc
@@ -282,27 +282,9 @@ void ConferenceClient::Join(
           RTC_LOG(LS_WARNING) << "Room info doesn't contain valid users.";
         } else {
           auto users = room_info->get_map()["participants"]->get_vector();
-          // Get current user's ID and trigger |on_success|. Make sure
-          // |on_success| is triggered before any other events because
+          // Make sure |on_success| is triggered before any other events because
           // OnUserJoined and OnStreamAdded should be triggered after join a
           // conference.
-          for (auto user_it = users.begin(); user_it != users.end();
-               user_it++) {
-            Participant* user_raw;
-            if (ParseUser(*user_it, &user_raw)) {
-              std::shared_ptr<Participant> user(user_raw);
-              const std::lock_guard<std::mutex> lock(conference_info_mutex_);
-              current_conference_info_->participants_.push_back(user);
-            } else if (on_failure) {
-              event_queue_->PostTask([on_failure]() {
-                std::unique_ptr<Exception> e(
-                    new Exception(ExceptionType::kConferenceUnknown,
-                                  "Failed to parse current user's info"));
-                on_failure(std::move(e));
-              });
-              break;
-            }
-          }
           for (auto it = users.begin(); it != users.end(); ++it) {
             TriggerOnUserJoined(*it, true);
           }

--- a/talk/owt/sdk/conference/conferenceclient.cc
+++ b/talk/owt/sdk/conference/conferenceclient.cc
@@ -300,8 +300,8 @@ void ConferenceClient::Join(
                                   "Failed to parse current user's info"));
                 on_failure(std::move(e));
               });
+              break;
             }
-            break;
           }
           for (auto it = users.begin(); it != users.end(); ++it) {
             TriggerOnUserJoined(*it, true);


### PR DESCRIPTION
I haven't got the point why put the "break; " statement in the bottom of the iteration,  so I think maybe this is a typo, maybe it should be in the bottom of on_failure branch. (the first user in users vector is not current user but the first user entering the room, so does it have any other special meanings here?)

```
auto users = room_info->get_map()["participants"]->get_vector();
// Get current user's ID and trigger |on_success|. Make sure
// |on_success| is triggered before any other events because
// OnUserJoined and OnStreamAdded should be triggered after join a
// conference.
for (auto user_it = users.begin(); user_it != users.end();
     user_it++) {
  Participant* user_raw;
  if (ParseUser(*user_it, &user_raw)) {
    std::shared_ptr<Participant> user(user_raw);
    const std::lock_guard<std::mutex> lock(conference_info_mutex_);
    current_conference_info_->participants_.push_back(user);
  } else if (on_failure) {
    event_queue_->PostTask([on_failure]() {
      std::unique_ptr<Exception> e(
          new Exception(ExceptionType::kConferenceUnknown,
                        "Failed to parse current user's info"));
      on_failure(std::move(e));
    });
    break;
  }
  //original break; stays here
}

```

And actually I have another question, most of users will be added to the current_conference_info_->participants_ twice, first time is in the iteration we talk about just now. The second time is in  `TriggerOnUserJoined` call.

```c++
for (auto it = users.begin(); it != users.end(); ++it) {
   TriggerOnUserJoined(*it, true);
}
```

```c++
void ConferenceClient::TriggerOnUserJoined(sio::message::ptr user_info,
                                           bool joining) {
  Participant* user_raw;
  if (ParseUser(user_info, &user_raw)) {
    std::shared_ptr<Participant> user(user_raw);
    current_conference_info_->AddParticipant(user);
    if (!joining) {
      const std::lock_guard<std::mutex> lock(observer_mutex_);
      for (auto its = observers_.begin(); its != observers_.end(); ++its) {
        auto& o = (*its).get();
        event_queue_->PostTask([&o, user] { o.OnParticipantJoined(user); });
      }
    }
  }
}
```
Although `current_conference_info_->AddParticipant` method will check whether use is already in the vector, but it may confuse people who read this part of code.
