### PR TITLE
Fix race conditions during exiting.

### DIFF
--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -39,6 +39,7 @@ bool PeerConnectionChannel::InitializePeerConnection() {
   }
   if (pc_thread_ == nullptr) {
     pc_thread_ = rtc::Thread::CreateWithSocketServer();
+    pc_thread_->SetName("pc_thread", nullptr);
     pc_thread_->Start();
   }
   RTC_CHECK(peer_connection_);
@@ -98,6 +99,9 @@ PeerConnectionInterface::SignalingState PeerConnectionChannel::SignalingState()
     const {
   RTC_CHECK(peer_connection_);
   return peer_connection_->signaling_state();
+}
+void PeerConnectionChannel::ClosePc(){
+  pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeClosePeerConnection, nullptr);
 }
 void PeerConnectionChannel::OnMessage(rtc::Message* msg) {
   RTC_CHECK(peer_connection_);

--- a/talk/owt/sdk/base/peerconnectionchannel.h
+++ b/talk/owt/sdk/base/peerconnectionchannel.h
@@ -75,6 +75,7 @@ class PeerConnectionChannel : public rtc::MessageHandler,
   // message to PeerConnectionChannel.
   virtual void CreateOffer() = 0;
   virtual void CreateAnswer() = 0;
+  virtual void ClosePc();
   // Message looper event
   virtual void OnMessage(rtc::Message* msg) override;
   // PeerConnectionObserver

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -58,6 +58,7 @@ PeerConnectionDependencyFactory::PeerConnectionDependencyFactory()
   network_monitor_ = nullptr;
 #endif
   encoded_frame_ = GlobalConfiguration::GetEncodedVideoFrameEnabled();
+  pc_thread_->SetName("peerconnection_dependency_factory_thread", nullptr);
   pc_thread_->Start();
 }
 PeerConnectionDependencyFactory::~PeerConnectionDependencyFactory() {}
@@ -178,7 +179,7 @@ void PeerConnectionDependencyFactory::
       webrtc::CreateBuiltinAudioEncoderFactory(),
       webrtc::CreateBuiltinAudioDecoderFactory(), std::move(encoder_factory),
       std::move(decoder_factory), nullptr, nullptr);
-
+  pc_factory_->AddRef();
   RTC_LOG(LS_INFO) << "CreatePeerConnectionOnCurrentThread finished.";
 }
 

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -200,6 +200,8 @@ class P2PClient final
   virtual void OnSignalingMessage(const std::string& message, const std::string& sender);
   virtual void OnServerDisconnected();
   // Handle events from P2PPeerConnectionChannel
+  // Triggered when the WebRTC session is ended.
+  virtual void OnStopped(const std::string& remote_id);
   // Triggered when remote user send data via data channel.
   // Currently, data is string.
   virtual void OnMessageReceived(const std::string& remote_id,
@@ -222,6 +224,9 @@ class P2PClient final
   std::shared_ptr<P2PSignalingChannelInterface> signaling_channel_;
   std::unordered_map<std::string, std::shared_ptr<P2PPeerConnectionChannel>>
       pc_channels_;
+  std::mutex pc_channels_mutex_;
+  std::vector<std::shared_ptr<P2PPeerConnectionChannel>> removed_pc_channels_;
+  std::mutex removed_pc_channels_mutex_;
   std::string local_id_;
   std::vector<std::reference_wrapper<P2PClientObserver>> observers_;
   P2PClientConfiguration configuration_;

--- a/talk/owt/sdk/p2p/objc/P2PPeerConnectionChannelObserverObjcImpl.h
+++ b/talk/owt/sdk/p2p/objc/P2PPeerConnectionChannelObserverObjcImpl.h
@@ -21,6 +21,7 @@ class P2PPeerConnectionChannelObserverObjcImpl
                          const std::string& message) override;
   void OnStreamAdded(
       std::shared_ptr<owt::base::RemoteStream> stream) override;
+  void OnStopped(const std::string& remote_id) override;
   // Jianjun TODO: Remove OnStreamRemoved event
   void OnStreamRemoved(
       std::shared_ptr<owt::base::RemoteStream> stream);

--- a/talk/owt/sdk/p2p/objc/P2PPeerConnectionChannelObserverObjcImpl.mm
+++ b/talk/owt/sdk/p2p/objc/P2PPeerConnectionChannelObserverObjcImpl.mm
@@ -31,6 +31,12 @@ void P2PPeerConnectionChannelObserverObjcImpl::OnStreamRemoved(
     std::shared_ptr<owt::base::RemoteStream> stream) {
   TriggerStreamRemoved(stream);
 }
+
+void P2PPeerConnectionChannelObserverObjcImpl::OnStopped(
+    const std::string& remote_id) {
+  [_observer onStoppedFrom:[NSString stringWithUTF8String:remote_id.c_str()]];
+}
+
 void P2PPeerConnectionChannelObserverObjcImpl::TriggerStreamRemoved(
     std::shared_ptr<owt::base::RemoteStream> stream) {
   if (remote_streams_.find(stream->Id()) == remote_streams_.end()) {

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -33,6 +33,8 @@ class P2PPeerConnectionChannelObserver {
   // Triggered when a new stream is added.
   virtual void OnStreamAdded(
       std::shared_ptr<RemoteStream> stream) = 0;
+  // Triggered when the WebRTC session is ended.
+  virtual void OnStopped(const std::string& remote_id) = 0;
 };
 // An instance of P2PPeerConnectionChannel manages a session for a specified
 // remote client.
@@ -137,6 +139,7 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
       std::function<void(std::unique_ptr<Exception>)> failure = nullptr);
   // Publish and/or unpublish all streams in pending stream list.
   void DrainPendingStreams();
+  void TriggerOnStopped();
   void CheckWaitedList();  // Check pending streams and negotiation requests.
   void SendStop(std::function<void()> on_success,
                 std::function<void(std::unique_ptr<Exception>)> on_failure);

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannelobservercppimpl.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannelobservercppimpl.cc
@@ -13,5 +13,9 @@ void P2PPeerConnectionChannelObserverCppImpl::OnStreamAdded(
     std::shared_ptr<RemoteStream> stream) {
   peer_client_.OnStreamAdded(stream);
 }
+void P2PPeerConnectionChannelObserverCppImpl::OnStopped(
+    const std::string& remote_id) {
+  peer_client_.OnStopped(remote_id);
+}
 }
 }

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannelobservercppimpl.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannelobservercppimpl.h
@@ -20,9 +20,13 @@ class P2PPeerConnectionChannelObserverCppImpl
       : peer_client_(peer_client) {}
   // Triggered when remote user send data via data channel.
   // Currently, data is string type.
-  virtual void OnMessageReceived(const std::string& remote_id, const std::string& message);
+  virtual void OnMessageReceived(const std::string& remote_id,
+                                 const std::string& message) override;
   // Triggered when a new stream is added.
-  virtual void OnStreamAdded(std::shared_ptr<RemoteStream> stream);
+  virtual void OnStreamAdded(std::shared_ptr<RemoteStream> stream) override;
+  // Triggered when the WebRTC session is ended.
+  virtual void OnStopped(const std::string& remote_id) override;
+
  private:
   P2PClient& peer_client_;
 };


### PR DESCRIPTION
A side effect of this change is memory usage increase because it moves ended channel to a vector instead of dispose them immediately.

This change also add an reference to `pc_factory_ `when it is created. It causes memory leak but fixes hang issue when application exits. AtExitManager might be needed to eventually fix this issue.