### PR TITLE
Fix undefined symbols error for iOS.

### DIFF
--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -140,10 +140,10 @@ void PeerConnectionDependencyFactory::
 #endif
   rtc::scoped_refptr<AudioDeviceModule> adm;
 
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
   // Raw audio frame
   // if adm is nullptr, voe_base will initilize it with the default internal
   // adm.
-#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
   if (GlobalConfiguration::GetCustomizedAudioInputEnabled()) {
     // Create ADM on worker thred as RegisterAudioCallback is invoked there.
     adm = worker_thread->Invoke<rtc::scoped_refptr<AudioDeviceModule>>(

--- a/talk/owt/sdk/base/stream.cc
+++ b/talk/owt/sdk/base/stream.cc
@@ -150,6 +150,7 @@ void Stream::SetAudioTracksEnabled(bool enabled) {
   }
 }
 
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
 void Stream::AttachVideoRenderer(VideoRendererInterface& renderer) {
   if (media_stream_ == nullptr) {
     RTC_LOG(LS_ERROR) << "Cannot attach an audio only stream to a renderer.";
@@ -197,8 +198,6 @@ void Stream::AttachAudioPlayer(AudioPlayerInterface& player) {
   RTC_LOG(LS_INFO) << "Attached the stream to a renderer.";
 }
 
-
-#if defined(WEBRTC_WIN)
 void Stream::AttachVideoRenderer(VideoRenderWindow& render_window) {
   if (media_stream_ == nullptr) {
     RTC_LOG(LS_ERROR) << "Cannot attach an audio only stream to a renderer.";

--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -75,13 +75,6 @@ class Stream {
   virtual void EnableAudio();
   /// Enable all video tracks of the stream.
   virtual void EnableVideo();
-  /// Attach the stream to a renderer to receive ARGB/I420 frames for local or
-  /// remote stream. Be noted if you turned hardware acceleration on, calling
-  /// this API on remote stream will have no effect.
-  virtual void AttachVideoRenderer(VideoRendererInterface& renderer);
-  /// Attach the stream to an audio player that receives PCM data besides sending to
-  /// audio output device.
-  virtual void AttachAudioPlayer(AudioPlayerInterface& player);
   /**
     @brief Returns a user-defined attribute map.
     @details These attributes are defined by publisher. P2P mode always return
@@ -98,10 +91,17 @@ class Stream {
     from mixed stream, it will be set as kMixed.
   */
   virtual StreamSourceInfo Source() const;
-#if defined(WEBRTC_WIN)
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
+  /// Attach the stream to a renderer to receive ARGB/I420 frames for local or
+  /// remote stream. Be noted if you turned hardware acceleration on, calling
+  /// this API on remote stream will have no effect.
+  virtual void AttachVideoRenderer(VideoRendererInterface& renderer);
   /// Attach the stream to a renderer to receive frames from decoder.
   /// Both I420 frame and native surface is supported.
   virtual void AttachVideoRenderer(VideoRenderWindow& render_window);
+  /// Attach the stream to an audio player that receives PCM data besides sending to
+  /// audio output device.
+  virtual void AttachAudioPlayer(AudioPlayerInterface& player);
 #endif
   /// Detach the stream from its renderer.
   virtual void DetachVideoRenderer();


### PR DESCRIPTION
Some features are only available on Windows.