### PR TITLE
Define OWT_USE_H265 when rtc_use_h265 is true.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -234,7 +234,7 @@ deps = {
     Var('chromium_git') + '/infra/luci/client-py.git' + '@' +  Var('swarming_revision'),
   # WebRTC-only dependencies (not present in Chromium).
   'src/third_party/webrtc':
-    Var('deps_webrtc_git') + '/owt-deps-webrtc' + '@' + '4729846cd2a25f029be5ce6de6fe393f43b32b09',
+    Var('deps_webrtc_git') + '/owt-deps-webrtc' + '@' + '3767c065136088718566d708971de4c669959b33',
   'src/third_party/accessibility_test_framework': {
     'packages': [
         {

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -160,6 +160,8 @@ static_library("owt_sdk_base") {
   defines += [ "USE_BUILTIN_SW_CODECS" ]
   if (!rtc_use_h265) {
     defines += [ "DISABLE_H265" ]
+  } else {
+    defines += [ "OWT_USE_H265" ]
   }
   if (is_win || is_linux) {
     # Custom audio/video input and output.


### PR DESCRIPTION
To unify all HEVC switches, we will use `owt_use_h265` in the future.

Fix #222.