### PR TITLE
Remove pc_thread_ from PeerConnectionChannel.

### DIFF
--- a/talk/owt/sdk/base/functionalobserver.cc
+++ b/talk/owt/sdk/base/functionalobserver.cc
@@ -51,6 +51,25 @@ void FunctionalSetSessionDescriptionObserver::OnFailure(
     on_failure_(error);
   }
 }
+
+FunctionalSetRemoteDescriptionObserver::FunctionalSetRemoteDescriptionObserver(
+    std::function<void(webrtc::RTCError error)> on_complete)
+    : on_complete_(on_complete) {}
+
+rtc::scoped_refptr<FunctionalSetRemoteDescriptionObserver>
+FunctionalSetRemoteDescriptionObserver::Create(
+    std::function<void(webrtc::RTCError error)> on_complete) {
+  return new rtc::RefCountedObject<FunctionalSetRemoteDescriptionObserver>(
+      on_complete);
+}
+
+void FunctionalSetRemoteDescriptionObserver::OnSetRemoteDescriptionComplete(
+    webrtc::RTCError error) {
+  if (on_complete_ != nullptr) {
+    on_complete_(std::move(error));
+  }
+}
+
 FunctionalStatsObserver::FunctionalStatsObserver(
     std::function<void(std::shared_ptr<ConnectionStats>)> on_complete)
     : on_complete_(on_complete) {}

--- a/talk/owt/sdk/base/functionalobserver.h
+++ b/talk/owt/sdk/base/functionalobserver.h
@@ -47,6 +47,22 @@ class FunctionalSetSessionDescriptionObserver
   std::function<void()> on_success_;
   std::function<void(const std::string& error)> on_failure_;
 };
+
+class FunctionalSetRemoteDescriptionObserver
+    : public webrtc::SetRemoteDescriptionObserverInterface {
+ public:
+  static rtc::scoped_refptr<FunctionalSetRemoteDescriptionObserver> Create(
+      std::function<void(webrtc::RTCError error)> on_complete);
+  virtual void OnSetRemoteDescriptionComplete(webrtc::RTCError error) override;
+
+ protected:
+  FunctionalSetRemoteDescriptionObserver(
+      std::function<void(webrtc::RTCError error)> on_complete);
+
+ private:
+  std::function<void(webrtc::RTCError error)> on_complete_;
+};
+
 // A StatsObserver implementation used to invoke user defined function to
 // retrieve current statistowt data.
 class FunctionalStatsObserver : public webrtc::StatsObserver {

--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -11,10 +11,9 @@ namespace owt {
 namespace base {
 PeerConnectionChannel::PeerConnectionChannel(
     PeerConnectionChannelConfiguration configuration)
-    : pc_thread_(nullptr),
-      configuration_(configuration),
-      factory_(nullptr),
-      peer_connection_(nullptr) {}
+    : configuration_(configuration),
+      peer_connection_(nullptr),
+      factory_(nullptr) {}
 PeerConnectionChannel::~PeerConnectionChannel() {
   if (peer_connection_ != nullptr) {
     peer_connection_->Close();
@@ -35,13 +34,7 @@ bool PeerConnectionChannel::InitializePeerConnection() {
     RTC_DCHECK(false);
     return false;
   }
-  if (pc_thread_ == nullptr) {
-    pc_thread_ = rtc::Thread::CreateWithSocketServer();
-    pc_thread_->SetName("pc_thread", nullptr);
-    pc_thread_->Start();
-  }
   RTC_CHECK(peer_connection_);
-  RTC_CHECK(pc_thread_);
   rtc::NetworkMonitorInterface* network_monitor = factory_->NetworkMonitor();
   if (network_monitor) {
     network_monitor->SignalNetworksChanged.connect(
@@ -111,155 +104,7 @@ PeerConnectionInterface::SignalingState PeerConnectionChannel::SignalingState()
   RTC_CHECK(peer_connection_);
   return peer_connection_->signaling_state();
 }
-void PeerConnectionChannel::ClosePc(){
-  pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeClosePeerConnection, nullptr);
-}
-void PeerConnectionChannel::OnMessage(rtc::Message* msg) {
-  RTC_CHECK(peer_connection_);
-  if (peer_connection_->signaling_state() ==
-      webrtc::PeerConnectionInterface::SignalingState::kClosed) {
-    RTC_LOG(LS_WARNING)
-        << "Attempt to perform PeerConnection operation when it is closed.";
-    return;
-  }
-  switch (msg->message_id) {
-    case kMessageTypeClosePeerConnection:
-      peer_connection_->Close();
-      break;
-    case kMessageTypeCreateOffer: {
-      rtc::TypedMessageData<
-          scoped_refptr<FunctionalCreateSessionDescriptionObserver>>* param =
-          static_cast<rtc::TypedMessageData<
-              scoped_refptr<FunctionalCreateSessionDescriptionObserver>>*>(
-              msg->pdata);
-      peer_connection_->CreateOffer(
-          param->data(),
-          webrtc::PeerConnectionInterface::RTCOfferAnswerOptions());
-      delete param;
-      break;
-    }
-    case kMessageTypeCreateAnswer: {
-      rtc::TypedMessageData<
-          scoped_refptr<FunctionalCreateSessionDescriptionObserver>>* param =
-          static_cast<rtc::TypedMessageData<
-              scoped_refptr<FunctionalCreateSessionDescriptionObserver>>*>(
-              msg->pdata);
-      peer_connection_->CreateAnswer(
-          param->data(),
-          webrtc::PeerConnectionInterface::RTCOfferAnswerOptions());
-      delete param;
-      break;
-    }
-    case kMessageTypeCreateDataChannel: {
-      rtc::TypedMessageData<std::string>* param =
-          static_cast<rtc::TypedMessageData<std::string>*>(msg->pdata);
-      webrtc::DataChannelInit config;
-      data_channel_ =
-          peer_connection_->CreateDataChannel(param->data(), &config);
-      data_channel_->RegisterObserver(this);
-      RTC_LOG(LS_INFO) << "Created data channel.";
-      delete param;
-      break;
-    }
-    case kMessageTypeSetLocalDescription: {
-      SetSessionDescriptionMessage* param =
-          static_cast<SetSessionDescriptionMessage*>(msg->pdata);
-      // Set codec preference.
-      webrtc::SessionDescriptionInterface* desc = param->description;
-      std::string sdp_string;
-      if (!desc->ToString(&sdp_string)) {
-        RTC_LOG(LS_ERROR) << "Error parsing local description.";
-        RTC_DCHECK(false);
-      }
-      std::vector<AudioCodec> audio_codecs;
-      for (auto& audio_enc_param : configuration_.audio) {
-        audio_codecs.push_back(audio_enc_param.codec.name);
-      }
-      sdp_string = SdpUtils::SetPreferAudioCodecs(sdp_string, audio_codecs);
-      std::vector<VideoCodec> video_codecs;
-      for (auto& video_enc_param : configuration_.video) {
-        video_codecs.push_back(video_enc_param.codec.name);
-      }
-      sdp_string = SdpUtils::SetPreferVideoCodecs(sdp_string, video_codecs);
-      webrtc::SessionDescriptionInterface* new_desc(
-          webrtc::CreateSessionDescription(desc->type(), sdp_string, nullptr));
-      peer_connection_->SetLocalDescription(param->observer, new_desc);
-      delete param;
-      break;
-    }
-    case kMessageTypeSetRemoteDescription: {
-      SetSessionDescriptionMessage* param =
-          static_cast<SetSessionDescriptionMessage*>(msg->pdata);
-      // Set codec preference.
-      webrtc::SessionDescriptionInterface* desc = param->description;
-      std::string sdp_string;
-      if (!desc->ToString(&sdp_string)) {
-        RTC_LOG(LS_ERROR) << "Error parsing local description.";
-        RTC_DCHECK(false);
-      }
-      webrtc::SessionDescriptionInterface* new_desc(
-          webrtc::CreateSessionDescription(desc->type(), sdp_string, nullptr));
-      peer_connection_->SetRemoteDescription(param->observer, new_desc);
-      delete param;
-      break;
-    }
-    case kMessageTypeSetRemoteIceCandidate: {
-      rtc::TypedMessageData<webrtc::IceCandidateInterface*>* param =
-          static_cast<rtc::TypedMessageData<webrtc::IceCandidateInterface*>*>(
-              msg->pdata);
-      peer_connection_->AddIceCandidate(param->data());
-      delete param;
-      break;
-    }
-    case kMessageTypeRemoveStream: {
-      rtc::ScopedRefMessageData<MediaStreamInterface>* param =
-          static_cast<rtc::ScopedRefMessageData<MediaStreamInterface>*>(
-              msg->pdata);
-      MediaStreamInterface* stream = param->data();
-      for (const auto track : stream->GetAudioTracks()) {
-        RTC_CHECK(peer_connection_);
-        std::vector<rtc::scoped_refptr<webrtc::RtpSenderInterface>> senders =
-            peer_connection_->GetSenders();
-        if (senders.size() == 0) {
-          return;
-        }
-        for (auto sender : senders) {
-          auto sender_track = sender->track();
-          if (sender_track != nullptr && sender_track->id() == track->id()) {
-            peer_connection_->RemoveTrack(sender);
-            break;
-          }
-        }
-      }
 
-      for (const auto track : stream->GetVideoTracks()) {
-        RTC_CHECK(peer_connection_);
-        std::vector<rtc::scoped_refptr<webrtc::RtpSenderInterface>> senders =
-            peer_connection_->GetSenders();
-        if (senders.size() == 0) {
-          return;
-        }
-        for (auto sender : senders) {
-          auto sender_track = sender->track();
-          if (sender_track != nullptr && sender_track->id() == track->id()) {
-            peer_connection_->RemoveTrack(sender);
-            break;
-          }
-        }
-      }
-      delete param;
-      break;
-    }
-    case kMessageTypeGetStats: {
-      GetStatsMessage* param = static_cast<GetStatsMessage*>(msg->pdata);
-      peer_connection_->GetStats(param->observer, nullptr, param->level);
-      delete param;
-      break;
-    }
-    default:
-      RTC_LOG(LS_WARNING) << "Unknown message type.";
-  }
-}
 void PeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess() {
   RTC_LOG(LS_INFO) << "Set remote sdp success.";
   if (peer_connection_->remote_description() &&
@@ -271,6 +116,16 @@ void PeerConnectionChannel::OnSetRemoteSessionDescriptionFailure(
     const std::string& error) {
   RTC_LOG(LS_INFO) << "Set remote sdp failed.";
 }
+
+void PeerConnectionChannel::OnSetRemoteDescriptionComplete(
+    webrtc::RTCError error) {
+  if (error.ok()) {
+    OnSetRemoteSessionDescriptionSuccess();
+  } else {
+    OnSetRemoteSessionDescriptionFailure(error.message());
+  }
+}
+
 void PeerConnectionChannel::OnCreateSessionDescriptionSuccess(
     webrtc::SessionDescriptionInterface* desc) {
   RTC_LOG(LS_INFO) << "Create sdp success.";

--- a/talk/owt/sdk/base/peerconnectionchannel.h
+++ b/talk/owt/sdk/base/peerconnectionchannel.h
@@ -56,10 +56,10 @@ struct PeerConnectionChannelConfiguration
   /// Indicate whether this PeerConnection is used for sending encoded frame.
   bool encoded_video_frame_;
 };
-class PeerConnectionChannel : public rtc::MessageHandler,
-                              public webrtc::PeerConnectionObserver,
-                              public webrtc::DataChannelObserver,
-                              public sigslot::has_slots<> {
+class PeerConnectionChannel
+    : public webrtc::PeerConnectionObserver,
+      public webrtc::DataChannelObserver,
+      public sigslot::has_slots<> {
  public:
   PeerConnectionChannel(PeerConnectionChannelConfiguration configuration);
  protected:
@@ -75,15 +75,13 @@ class PeerConnectionChannel : public rtc::MessageHandler,
   // message to PeerConnectionChannel.
   virtual void CreateOffer() = 0;
   virtual void CreateAnswer() = 0;
-  virtual void ClosePc();
+
   virtual void AddTransceiver(
       rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track,
       const webrtc::RtpTransceiverInit& init);
   virtual void AddTransceiver(cricket::MediaType media_type,
                               const webrtc::RtpTransceiverInit& init);
-  // Message looper event
-  virtual void OnMessage(rtc::Message* msg) override;
-  // PeerConnectionObserver
+  // PeerConnectionObserver.
   virtual void OnStateChange(webrtc::StatsReport::StatsType state_changed) {}
   virtual void OnSignalingChange(
       PeerConnectionInterface::SignalingState new_state) override;
@@ -115,27 +113,14 @@ class PeerConnectionChannel : public rtc::MessageHandler,
   virtual void OnSetLocalSessionDescriptionFailure(const std::string& error);
   virtual void OnSetRemoteSessionDescriptionSuccess();
   virtual void OnSetRemoteSessionDescriptionFailure(const std::string& error);
+
+  virtual void OnSetRemoteDescriptionComplete(webrtc::RTCError error);
+
   // Fired when networks changed. (Only works on iOS)
   virtual void OnNetworksChanged();
-  enum MessageType : int {
-    kMessageTypeCreateOffer = 101,
-    kMessageTypeCreateAnswer,
-    kMessageTypeCreateDataChannel,
-    kMessageTypeSetLocalDescription,
-    kMessageTypeSetRemoteDescription,
-    kMessageTypeSetRemoteIceCandidate,
-    kMessageTypeRemoveStream,
-    kMessageTypeAddTransceiver,
-    kMessageTypeClosePeerConnection,
-    kMessageTypeGetStats,
-    kMessageTypeCreateNetworkMonitor=201,
-  };
-  std::unique_ptr<Thread> pc_thread_;
+
   PeerConnectionChannelConfiguration configuration_;
-  // Use this data channel to send p2p messages.
-  // Use a map if we need more than one data channels for a PeerConnection in
-  // the future.
-  rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel_;
+  rtc::scoped_refptr<webrtc::PeerConnectionInterface> peer_connection_;
   webrtc::MediaConstraints media_constraints_;
   // Direction of audio and video transceivers. In conference mode, there are at
   // most 1 audio transceiver and 1 video transceiver.
@@ -150,7 +135,6 @@ class PeerConnectionChannel : public rtc::MessageHandler,
   // |factory_| is got from PeerConnectionDependencyFactory::Get() which is
   // shared among all PeerConnectionChannels.
   rtc::scoped_refptr<PeerConnectionDependencyFactory> factory_;
-  rtc::scoped_refptr<webrtc::PeerConnectionInterface> peer_connection_;
 };
 }
 }

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -87,7 +87,7 @@ P2PPeerConnectionChannel::P2PPeerConnectionChannel(
       remote_id_(remote_id),
       session_state_(kSessionStateReady),
       negotiation_needed_(false),
-      set_remote_sdp_task_(nullptr),
+      remote_sdp_to_be_set_(nullptr),
       last_disconnect_(
           std::chrono::time_point<std::chrono::system_clock>::max()),
       reconnect_timeout_(10),
@@ -123,8 +123,6 @@ P2PPeerConnectionChannel::P2PPeerConnectionChannel(
                                sender,
                                nullptr) {}
 P2PPeerConnectionChannel::~P2PPeerConnectionChannel() {
-  if (set_remote_sdp_task_)
-    delete set_remote_sdp_task_;
   if (signaling_sender_)
     delete signaling_sender_;
   ended_ = true;
@@ -281,14 +279,10 @@ void P2PPeerConnectionChannel::CreateOffer() {
           std::bind(
               &P2PPeerConnectionChannel::OnCreateSessionDescriptionFailure,
               this, std::placeholders::_1));
-  rtc::TypedMessageData<
-      scoped_refptr<FunctionalCreateSessionDescriptionObserver>>*
-      message_observer = new rtc::TypedMessageData<
-          scoped_refptr<FunctionalCreateSessionDescriptionObserver>>(observer);
-  RTC_LOG(LS_INFO) << "Post create offer";
-  pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeCreateOffer,
-                   message_observer);
+  peer_connection_->CreateOffer(
+      observer, webrtc::PeerConnectionInterface::RTCOfferAnswerOptions());
 }
+
 void P2PPeerConnectionChannel::CreateAnswer() {
   RTC_LOG(LS_INFO) << "Create answer.";
   scoped_refptr<FunctionalCreateSessionDescriptionObserver> observer =
@@ -299,14 +293,10 @@ void P2PPeerConnectionChannel::CreateAnswer() {
           std::bind(
               &P2PPeerConnectionChannel::OnCreateSessionDescriptionFailure,
               this, std::placeholders::_1));
-  rtc::TypedMessageData<
-      scoped_refptr<FunctionalCreateSessionDescriptionObserver>>*
-      message_observer = new rtc::TypedMessageData<
-          scoped_refptr<FunctionalCreateSessionDescriptionObserver>>(observer);
-  RTC_LOG(LS_INFO) << "Post create answer";
-  pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeCreateAnswer,
-                   message_observer);
+  peer_connection_->CreateAnswer(
+      observer, webrtc::PeerConnectionInterface::RTCOfferAnswerOptions());
 }
+
 void P2PPeerConnectionChannel::SendSignalingMessage(
     const Json::Value& data,
     std::function<void()> on_success,
@@ -446,33 +436,23 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
       RTC_LOG(LS_WARNING) << "Cannot parse received sdp.";
       return;
     }
-    webrtc::SessionDescriptionInterface* desc(
+    std::unique_ptr<webrtc::SessionDescriptionInterface> desc(
         webrtc::CreateSessionDescription(type, sdp, nullptr));
     if (!desc) {
       RTC_LOG(LS_ERROR) << "Failed to create session description.";
       return;
     }
-    scoped_refptr<FunctionalSetSessionDescriptionObserver> observer =
-        FunctionalSetSessionDescriptionObserver::Create(
-            std::bind(
-                &P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionSuccess,
-                this),
-            std::bind(
-                &P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionFailure,
-                this, std::placeholders::_1));
-    SetSessionDescriptionMessage* msg =
-        new SetSessionDescriptionMessage(observer.get(), desc);
     if (type == "offer" &&
         SignalingState() != webrtc::PeerConnectionInterface::kStable) {
       RTC_LOG(LS_INFO) << "Signaling state is " << SignalingState()
                        << ", set SDP later.";
-      if (set_remote_sdp_task_) {
-        delete set_remote_sdp_task_;
-      }
-      set_remote_sdp_task_ = msg;
+      remote_sdp_to_be_set_ = std::move(desc);
     } else {
-      RTC_LOG(LS_INFO) << "Post set remote desc";
-      pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeSetRemoteDescription, msg);
+      scoped_refptr<FunctionalSetRemoteDescriptionObserver> observer =
+          FunctionalSetRemoteDescriptionObserver::Create(std::bind(
+              &P2PPeerConnectionChannel::OnSetRemoteDescriptionComplete, this,
+              std::placeholders::_1));
+      peer_connection_->SetRemoteDescription(std::move(desc), observer);
     }
   } else if (type == "candidates") {
     string sdp_mid;
@@ -484,10 +464,8 @@ void P2PPeerConnectionChannel::OnMessageSignal(Json::Value& message) {
                               &sdp_mline_index);
     webrtc::IceCandidateInterface* ice_candidate = webrtc::CreateIceCandidate(
         sdp_mid, sdp_mline_index, candidate, nullptr);
-    rtc::TypedMessageData<webrtc::IceCandidateInterface*>* param =
-        new rtc::TypedMessageData<webrtc::IceCandidateInterface*>(
-            ice_candidate);
-    pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeSetRemoteIceCandidate, param);
+    peer_connection_->AddIceCandidate(ice_candidate);
+    delete ice_candidate;
   }
 }
 void P2PPeerConnectionChannel::OnMessageTracksAdded(
@@ -563,12 +541,14 @@ void P2PPeerConnectionChannel::OnSignalingChange(
   RTC_LOG(LS_INFO) << "Signaling state changed: " << new_state;
   switch (new_state) {
     case PeerConnectionInterface::SignalingState::kStable:
-      if (set_remote_sdp_task_) {
+      if (remote_sdp_to_be_set_) {
         RTC_LOG(LS_INFO) << "Set stored remote description.";
-        pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeSetRemoteDescription,
-                         set_remote_sdp_task_);
-        // Ownership will be transferred to message handler.
-        set_remote_sdp_task_ = nullptr;
+        scoped_refptr<FunctionalSetRemoteDescriptionObserver> observer =
+            FunctionalSetRemoteDescriptionObserver::Create(std::bind(
+                &P2PPeerConnectionChannel::OnSetRemoteDescriptionComplete, this,
+                std::placeholders::_1));
+        peer_connection_->SetRemoteDescription(std::move(remote_sdp_to_be_set_),
+                                               observer);
       } else {
         CheckWaitedList();
       }
@@ -711,6 +691,7 @@ void P2PPeerConnectionChannel::OnIceCandidate(
   json[kMessageDataKey] = signal;
   SendSignalingMessage(json);
 }
+
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
     webrtc::SessionDescriptionInterface* desc) {
   RTC_LOG(LS_INFO) << "Create sdp success.";
@@ -722,11 +703,9 @@ void P2PPeerConnectionChannel::OnCreateSessionDescriptionSuccess(
           std::bind(
               &P2PPeerConnectionChannel::OnSetLocalSessionDescriptionFailure,
               this, std::placeholders::_1));
-  SetSessionDescriptionMessage* msg =
-      new SetSessionDescriptionMessage(observer.get(), desc);
-  pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeSetLocalDescription, msg);
-  RTC_LOG(LS_INFO) << "Post set local desc";
+  peer_connection_->SetLocalDescription(observer, desc);
 }
+
 void P2PPeerConnectionChannel::OnCreateSessionDescriptionFailure(
     const std::string& error) {
   RTC_LOG(LS_INFO) << "Create sdp failed.";
@@ -820,6 +799,7 @@ void P2PPeerConnectionChannel::OnSetRemoteSessionDescriptionFailure(
   }
   Stop(nullptr, nullptr);
 }
+
 bool P2PPeerConnectionChannel::CheckNullPointer(
     uintptr_t pointer,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
@@ -843,10 +823,7 @@ void P2PPeerConnectionChannel::TriggerOnStopped() {
 }
 
 void P2PPeerConnectionChannel::CleanLastPeerConnection() {
-  if (set_remote_sdp_task_) {
-    delete set_remote_sdp_task_;
-    set_remote_sdp_task_ = nullptr;
-  }
+  remote_sdp_to_be_set_ = nullptr;
   negotiation_needed_ = false;
   last_disconnect_ = std::chrono::time_point<std::chrono::system_clock>::max();
 }
@@ -964,11 +941,12 @@ void P2PPeerConnectionChannel::GetConnectionStats(
   }
   rtc::scoped_refptr<FunctionalStatsObserver> observer =
       FunctionalStatsObserver::Create(std::move(on_success));
-  GetStatsMessage* stats_message = new GetStatsMessage(
+  // TODO: Move to spec-compliant GetStats() API.
+  peer_connection_->GetStats(
       observer, nullptr,
       webrtc::PeerConnectionInterface::kStatsOutputLevelStandard);
-  pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeGetStats, stats_message);
 }
+
 void P2PPeerConnectionChannel::GetStats(
     std::function<void(const webrtc::StatsReports& reports)> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
@@ -996,13 +974,13 @@ void P2PPeerConnectionChannel::GetStats(
     }
     return;
   }
-  RTC_LOG(LS_INFO) << "Get native stats";
+  RTC_LOG(LS_INFO) << "Get native stats.";
   rtc::scoped_refptr<FunctionalNativeStatsObserver> observer =
       FunctionalNativeStatsObserver::Create(std::move(on_success));
-  GetNativeStatsMessage* stats_message = new GetNativeStatsMessage(
+  // TODO: Move to spec-compliant GetStats() API.
+  peer_connection_->GetStats(
       observer, nullptr,
       webrtc::PeerConnectionInterface::kStatsOutputLevelStandard);
-  pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeGetStats, stats_message);
 }
 bool P2PPeerConnectionChannel::HaveLocalOffer() {
   return SignalingState() == webrtc::PeerConnectionInterface::kHaveLocalOffer;
@@ -1100,10 +1078,27 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
       std::shared_ptr<LocalStream> stream = *it;
       scoped_refptr<webrtc::MediaStreamInterface> media_stream =
           stream->MediaStream();
-      rtc::ScopedRefMessageData<MediaStreamInterface>* param =
-          new rtc::ScopedRefMessageData<MediaStreamInterface>(media_stream);
-      RTC_LOG(LS_INFO) << "Post remove stream";
-      pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeRemoveStream, param);
+      RTC_CHECK(peer_connection_);
+      for(const auto& track: media_stream->GetAudioTracks()){
+        const auto& senders = peer_connection_->GetSenders();
+        for (auto& s : senders) {
+          const auto& t = s->track();
+          if (t != nullptr && t->id() == track->id()) {
+            peer_connection_->RemoveTrack(s);
+            break;
+          }
+        }
+      }
+      for(const auto& track: media_stream->GetVideoTracks()){
+        const auto& senders = peer_connection_->GetSenders();
+        for (auto& s : senders) {
+          const auto& t = s->track();
+          if (t != nullptr && t->id() == track->id()) {
+            peer_connection_->RemoveTrack(s);
+            break;
+          }
+        }
+      }
       negotiation_needed = true;
     }
     pending_unpublish_streams_.clear();
@@ -1123,8 +1118,7 @@ void P2PPeerConnectionChannel::SendStop(
 }
 void P2PPeerConnectionChannel::ClosePeerConnection() {
   RTC_LOG(LS_INFO) << "Close peer connection.";
-  RTC_CHECK(pc_thread_);
-  PeerConnectionChannel::ClosePc();
+  peer_connection_->Close();
   ChangeSessionState(kSessionStateReady);
 }
 void P2PPeerConnectionChannel::CheckWaitedList() {
@@ -1181,12 +1175,14 @@ void P2PPeerConnectionChannel::OnDataChannelMessage(
     (*it)->OnMessageReceived(remote_id_, message);
   }
 }
+
 void P2PPeerConnectionChannel::CreateDataChannel(const std::string& label) {
-  rtc::TypedMessageData<std::string>* data =
-      new rtc::TypedMessageData<std::string>(label);
-  pc_thread_->Post(RTC_FROM_HERE, this, kMessageTypeCreateDataChannel, data);
+  webrtc::DataChannelInit config;
+  data_channel_ = peer_connection_->CreateDataChannel(label, &config);
+  data_channel_->RegisterObserver(this);
   OnNegotiationNeeded();
 }
+
 webrtc::DataBuffer P2PPeerConnectionChannel::CreateDataBuffer(
     const std::string& data) {
   rtc::CopyOnWriteBuffer buffer(data.c_str(), data.length());

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.h
@@ -160,6 +160,10 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   // Set remote capability flags based on UA.
   void HandleRemoteCapability(Json::Value& ua);
   void SendUaInfo();
+
+  // Use a map if we need more than one data channels for a PeerConnection in
+  // the future.
+  rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel_;
   P2PSignalingSenderInterface* signaling_sender_;
   std::string local_id_;
   std::string remote_id_;
@@ -193,7 +197,7 @@ class P2PPeerConnectionChannel : public P2PSignalingReceiverInterface,
   std::vector<P2PPeerConnectionChannelObserver*> observers_;
   std::unordered_map<std::string, std::function<void()>> publish_success_callbacks_;
   // Store remote SDP if it cannot be set currently.
-  SetSessionDescriptionMessage* set_remote_sdp_task_;
+  std::unique_ptr<webrtc::SessionDescriptionInterface> remote_sdp_to_be_set_;
   std::chrono::time_point<std::chrono::system_clock>
       last_disconnect_;  // Last time |peer_connection_| changes its state to
                          // "disconnect"


### PR DESCRIPTION
`PeerConnection` is thread safe in this version. No need to call it from `pc_thread_`.