### PR TITLE
Build unit test when specified

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -18,4 +18,8 @@ group("default") {
   if (owt_include_tests) {
     deps += [ "talk/owt:owt_tests" ]
   }
+  if (rtc_include_tests) {
+    deps += [ "//third_party/webrtc:rtc_unittests",
+              "//third_party/webrtc:video_engine_tests" ]
+  }
 }


### PR DESCRIPTION
Add dep to rtc unit tests so it will be built by default.