### PR TITLE
Enable temporal scalability for h.264 from MSDK & external encoder.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -238,7 +238,7 @@ deps = {
     Var('chromium_git') + '/infra/luci/client-py.git' + '@' +  Var('swarming_revision'),
   # WebRTC-only dependencies (not present in Chromium).
   'src/third_party/webrtc':
-    Var('deps_webrtc_git') + '/owt-deps-webrtc' + '@' + '2fa91a1fc71b324ab46483777d7e6da90c57d3c6',
+    Var('deps_webrtc_git') + '/owt-deps-webrtc' + '@' + '2ced2a8be6cdc1d48f5f5f4a88916151fd56b24c',
   'src/third_party/accessibility_test_framework': {
     'packages': [
         {

--- a/talk/owt/sdk/base/customizedvideoencoderproxy.cc
+++ b/talk/owt/sdk/base/customizedvideoencoderproxy.cc
@@ -14,6 +14,7 @@
 #include "webrtc/rtc_base/logging.h"
 #include "talk/owt/sdk/base/customizedencoderbufferhandle.h"
 #include "talk/owt/sdk/base/customizedvideoencoderproxy.h"
+#include "talk/owt/sdk/base/mediautils.h"
 #include "talk/owt/sdk/base/nativehandlebuffer.h"
 #include "talk/owt/sdk/include/cpp/owt/base/commontypes.h"
 // H.264 start code length.
@@ -191,6 +192,16 @@ int32_t CustomizedVideoEncoderProxy::Encode(
     info.codecSpecific.VP9.height[0] = encodedframe._encodedHeight;
     info.codecSpecific.VP9.width[0] = encodedframe._encodedWidth;
     info.codecSpecific.VP9.temporal_idx = kNoTemporalIdx;
+  } else if (codec_type_ == webrtc::kVideoCodecH264) {
+    int temporal_id = 0, priority_id = 0;
+    bool is_idr = false;
+    bool need_frame_marking = MediaUtils::GetH264TemporalInfo(
+        data_ptr, data_size, temporal_id, priority_id, is_idr);
+    if (need_frame_marking) {
+      info.codecSpecific.H264.temporal_idx = temporal_id;
+      info.codecSpecific.H264.idr_frame = is_idr;
+      info.codecSpecific.H264.base_layer_sync = (!is_idr && (temporal_id > 0));
+    }
   }
   // Generate a header describing a single fragment.
   webrtc::RTPFragmentationHeader header;

--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -13,6 +13,7 @@ std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
 std::unique_ptr<VideoDecoderInterface>
     GlobalConfiguration::video_decoder_ = nullptr;
+int GlobalConfiguration::h264_temporal_layers_ = 1;
 #if defined(WEBRTC_IOS)
 AudioProcessingSettings GlobalConfiguration::audio_processing_settings_ = {
     true, true, true, false};

--- a/talk/owt/sdk/base/mediautils.cc
+++ b/talk/owt/sdk/base/mediautils.cc
@@ -4,8 +4,14 @@
 #include <algorithm>
 #include <map>
 #include <string>
+#include "absl/types/optional.h"
+#include "webrtc/common_video/h264/h264_common.h"
+#include "webrtc/common_video/h264/prefix_parser.h"
 #include "webrtc/rtc_base/checks.h"
+#include "webrtc/rtc_base/bit_buffer.h"
+#include "system_wrappers/include/field_trial.h"
 #include "talk/owt/sdk/base/mediautils.h"
+
 namespace owt {
 namespace base {
 static const std::map<const std::string, const Resolution> resolution_name_map = {
@@ -73,6 +79,53 @@ std::string MediaUtils::VideoCodecToString(const VideoCodec& video_codec) {
     RTC_NOTREACHED();
     return "unknown";
   }
+}
+absl::optional<unsigned int> MediaUtils::GetH264TemporalLayers() {
+  std::string experiment_value =
+      webrtc::field_trial::FindFullName("OWT-H264TemporalLayers");
+  unsigned int layers = 1;
+  if (sscanf(experiment_value.c_str(), "%u", &layers) != 1)
+    return absl::nullopt;
+  layers = std::min(layers, 4u);
+  layers = std::max(layers, 1u);
+  return layers;
+}
+bool ParseSlice(const uint8_t* slice, size_t length, int& temporal_id, int& priority_id, bool& is_idr) {
+  using namespace webrtc;
+  webrtc::H264::NaluType nalu_type = webrtc::H264::ParseNaluType(slice[0]);
+  absl::optional<PrefixParser::PrefixState> prefix_state;
+  switch (nalu_type) {
+    case H264::NaluType::kPrefix: {
+      prefix_state = PrefixParser::ParsePrefix(
+          slice + webrtc::H264::kNaluTypeSize,
+                                 length - webrtc::H264::kNaluTypeSize);
+      break;
+    }
+    // Ignore all other cases as we only care about prefix NAL.
+    default:
+      break;
+  }
+  if (prefix_state.has_value()) {
+    temporal_id = prefix_state.value().temporal_id;
+    is_idr = prefix_state.value().idr_flag == 1 ? true : false;
+    priority_id = prefix_state.value().priority_id;
+    return true;
+  }
+
+  return false;
+}
+bool MediaUtils::GetH264TemporalInfo(uint8_t* buffer, size_t buffer_length,
+  int& temporal_id, int& priority_id, bool& is_idr) {
+  bool prefix_nal_found = false;
+  std::vector<webrtc::H264::NaluIndex> nalu_indices =
+      webrtc::H264::FindNaluIndices(buffer, buffer_length);
+  for (const webrtc::H264::NaluIndex& index : nalu_indices) {
+    prefix_nal_found = ParseSlice(&buffer[index.payload_start_offset],
+      index.payload_size, temporal_id, priority_id, is_idr);
+    if (prefix_nal_found)
+      return true;
+  }
+  return prefix_nal_found;
 }
 }  // namespace base
 }  // namespace owt

--- a/talk/owt/sdk/base/mediautils.h
+++ b/talk/owt/sdk/base/mediautils.h
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_MEDIAUTILS_H_
 #define OWT_BASE_MEDIAUTILS_H_
+#include "absl/types/optional.h"
 #include "talk/owt/sdk/include/cpp/owt/base/commontypes.h"
+
 namespace owt {
 namespace base {
 class MediaUtils {
@@ -13,6 +15,12 @@ class MediaUtils {
   static std::string VideoCodecToString(const VideoCodec& video_codec);
   static AudioCodec GetAudioCodecFromString(const std::string& codec_name);
   static VideoCodec GetVideoCodecFromString(const std::string& codec_name);
+  static absl::optional<unsigned int> GetH264TemporalLayers();
+  static bool GetH264TemporalInfo(uint8_t* buffer,
+                                  size_t buffer_length,
+                                  int& temporal_id,
+                                  int& priority_id,
+                                  bool& is_idr);
 };
 }
 }

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -95,6 +95,10 @@ void PeerConnectionDependencyFactory::
       GlobalConfiguration::GetAEC3Enabled()) {
     field_trial_ += "OWT-EchoCanceller3/Enabled/";
   }
+  // Set H.264 temporal layers. Ideally it should be set via RtpSenderParam
+  int h264_temporal_layers = GlobalConfiguration::GetH264TemporalLayers();
+  field_trial_ +=
+      "OWT-H264TemporalLayers/" + std::to_string(h264_temporal_layers) + std::string("/");
   webrtc::field_trial::InitFieldTrialsFromString(field_trial_.c_str());
   if (!rtc::InitializeSSL()) {
     RTC_LOG(LS_ERROR) << "Failed to initialize SSL.";
@@ -102,13 +106,13 @@ void PeerConnectionDependencyFactory::
     return;
   }
   worker_thread = rtc::Thread::CreateWithSocketServer();
-  ;
+
   worker_thread->SetName("worker_thread", nullptr);
   signaling_thread = rtc::Thread::CreateWithSocketServer();
-  ;
+
   signaling_thread->SetName("signaling_thread", nullptr);
   network_thread = rtc::Thread::CreateWithSocketServer();
-  ;
+
   network_thread->SetName("network_thread", nullptr);
   RTC_CHECK(worker_thread->Start() && signaling_thread->Start() &&
             network_thread->Start())

--- a/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
+++ b/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
@@ -922,14 +922,19 @@ void ConferencePeerConnectionChannel::SendPublishMessage(
             for (auto encoding :
                  configuration_.video[0].rtp_encoding_parameters) {
               webrtc::RtpEncodingParameters param;
-              param.rid = encoding.rid;
+              if (encoding.rid != "")
+                param.rid = encoding.rid;
               if (encoding.max_bitrate_bps != 0)
                 param.max_bitrate_bps = encoding.max_bitrate_bps;
               if (encoding.max_framerate != 0)
                 param.max_framerate = encoding.max_framerate;
-              if (param.scale_resolution_down_by > 0)
+              if (encoding.scale_resolution_down_by > 0)
                 param.scale_resolution_down_by =
                     encoding.scale_resolution_down_by;
+              if (encoding.num_temporal_layers > 0 &&
+                  encoding.num_temporal_layers <= 4) {
+                param.num_temporal_layers = encoding.num_temporal_layers;
+              }
               param.active = encoding.active;
               transceiver_init.send_encodings.push_back(param);
             }

--- a/talk/owt/sdk/include/cpp/owt/base/commontypes.h
+++ b/talk/owt/sdk/include/cpp/owt/base/commontypes.h
@@ -67,6 +67,9 @@ struct AudioCodecParameters {
 
 /// RTP endoding settings for a stream
 struct RtpEncodingParameters {
+  // number of temporal layers requested to encoder, if supported.
+  int num_temporal_layers = 1;
+
   //  Currently this is implemented for the entire rtp sender by using
   // the value of the first encoding parameter..
   int max_bitrate_bps = 0;
@@ -88,7 +91,7 @@ struct RtpEncodingParameters {
 
   // Value to use for RID RTP header extension.
   // Called "encodingId" in ORTC.
-  std::string rid;
+  std::string rid = "";
 };
 
 /// Audio encoding parameters.

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -84,6 +84,21 @@ class GlobalConfiguration {
       }
   }
   /**
+   @brief This function sets the temporal layers for H.264.
+
+   This API is added as upstream has not yet passed the temporal layer setting
+   in RtpEncodingParameters to H.264 encoder. Remove this API once upstream
+   implementation done.
+
+   @param num_temporal_layers Number of temporal layers for H.264. Value greater
+   than 4 or smaller than 1 will be ignored.
+  */
+  static void SetH264EncoderTemporalLayers(int layers) {
+    if (layers < 1 || layers > 4)
+      return;
+    h264_temporal_layers_ = layers;
+  }
+  /**
    @brief This function sets the customized video decoder to decode the encoded images.
    @param Customized video decoder
    */
@@ -136,7 +151,19 @@ class GlobalConfiguration {
   }
   static bool hardware_acceleration_enabled_;
 #endif
+  /**
+   @brief This function gets H.264 temporal layer settings.
 
+   This is added as upstream has not yet passed the temporal layer setting
+   in RtpEncodingParameters to H.264 encoder. Remove once upstream implementation
+   done.
+
+   @return temporal layer setting for H.264.
+  */
+  static int GetH264TemporalLayers() {
+    return h264_temporal_layers_;
+  }
+  static int h264_temporal_layers_;
   /**
    @brief This function gets whether encoded video frame input is enabled or not.
    @return true or false.


### PR DESCRIPTION
Also added a new GlobalConfiguraiton API: SetH264TemporalLayers() to
specify layers requested. Default to 1 and temporal scalability
disabled.