### PR TITLE
Enable owt dynamic library built out and fix adm init error issue.

### DIFF
--- a/build_overrides/ssl/BUILD.gn
+++ b/build_overrides/ssl/BUILD.gn
@@ -30,8 +30,8 @@ if (owt_use_openssl) {
       }
     } else {
       libs = [
-        "libeay32.lib",
-        "ssleay32.lib",
+        "crypto",
+        "ssl",
       ]
     }
     if (is_clang) {

--- a/scripts/build_linux.py
+++ b/scripts/build_linux.py
@@ -88,7 +88,7 @@ def ninjabuild(arch, scheme):
     if subprocess.call(['ninja', '-C', out_path], cwd=HOME_PATH, shell=False) != 0:
         return False
     src_lib_path = os.path.join(out_path, r'obj/talk/owt/libowt.a')
-    shutil.copy(src_lib_path, gen_lib_path(scheme))
+    # shutil.copy(src_lib_path, gen_lib_path(scheme))
     return True
 
 def runtest(scheme):

--- a/scripts/prepare_dev.py
+++ b/scripts/prepare_dev.py
@@ -19,6 +19,7 @@ THIRD_PARTY_PATH = os.path.join(HOME_PATH, 'third_party')
 LIBSRTP_PATH = os.path.join(THIRD_PARTY_PATH, 'libsrtp')
 LIBJPEG_TURBO_PATH = os.path.join(THIRD_PARTY_PATH, 'libjpeg_turbo')
 WEBRTC_OVERRIDES_PATH = os.path.join(THIRD_PARTY_PATH, 'webrtc_overrides')
+LIBYUV_PATH = os.path.join(THIRD_PARTY_PATH, 'libyuv')
 BUILD_PATH = os.path.join(HOME_PATH, 'build')
 TOOL_PATH = os.path.join(HOME_PATH, 'tools')
 BASE_PATH = os.path.join(HOME_PATH, 'base')
@@ -54,6 +55,10 @@ def _patch():
     subprocess.call(['git', 'am', '--skip'], shell=useShell, cwd=LIBJPEG_TURBO_PATH)
   #if (subprocess.call(['git', 'am', os.path.join(PATCH_PATH, '0012-ios-Adds-CFBundleShortVersionString-to-the-plist-for.patch')], shell=useShell, cwd=TESTING_PATH)) != 0:
     subprocess.call(['git', 'am', '--skip'], shell=useShell, cwd=TESTING_PATH)
+  if (subprocess.call(['git', 'am', os.path.join(PATCH_PATH, '0001-Export-symbols-of-jsoncpp.patch')], shell=useShell, cwd=THIRD_PARTY_PATH)) != 0:
+    subprocess.call(['git', 'am', '--skip'], shell=useShell, cwd=THIRD_PARTY_PATH)
+  if (subprocess.call(['git', 'am', os.path.join(PATCH_PATH, '0001-Export-symbols-of-libyuv.patch')], shell=useShell, cwd=LIBYUV_PATH)) != 0:
+    subprocess.call(['git', 'am', '--skip'], shell=useShell, cwd=LIBYUV_PATH)
 
 def main(argv):
   _patch()

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -48,17 +48,17 @@ static_library("owt_deps") {
   complete_static_lib = true
 }
 if (!is_ios) {
-  static_library("owt") {
+  shared_library("owt") {
     deps = [
       ":owt_sdk_base",
-      ":owt_sdk_conf",
+      # ":owt_sdk_conf",
       ":owt_sdk_p2p",
       "//third_party/protobuf:protobuf_lite",
       "//third_party/webrtc",
       "//third_party/webrtc:webrtc",
       "//third_party/webrtc/api:libjingle_peerconnection_api",
     ]
-    complete_static_lib = true
+    # complete_static_lib = true
   }
 }
 static_library("owt_sdk_base") {
@@ -226,6 +226,9 @@ static_library("owt_sdk_base") {
       "-Wno-reorder",
     ]
   }
+
+  configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
+  configs += [ "//build/config/gcc:symbol_visibility_default" ]
 }
 static_library("owt_sdk_p2p") {
   deps = [
@@ -254,6 +257,9 @@ static_library("owt_sdk_p2p") {
   if (is_clang) {
     configs -= [ "//build/config/clang:find_bad_constructs" ]
   }
+
+  configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
+  configs += [ "//build/config/gcc:symbol_visibility_default" ]
 }
 static_library("owt_sdk_conf") {
   deps = [
@@ -282,6 +288,9 @@ static_library("owt_sdk_conf") {
   if (is_clang) {
     configs -= [ "//build/config/clang:find_bad_constructs" ]
   }
+
+  configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
+  configs += [ "//build/config/gcc:symbol_visibility_default" ]
 }
 if (is_ios) {
   static_library("owt_sdk_objc") {

--- a/talk/owt/patches/0001-Export-symbols-of-jsoncpp.patch
+++ b/talk/owt/patches/0001-Export-symbols-of-jsoncpp.patch
@@ -1,0 +1,27 @@
+From 3f42957b5e3f4224d6948881587a278aa18542f9 Mon Sep 17 00:00:00 2001
+From: "Liu, Kai1" <kai1.liu@intel.com>
+Date: Tue, 10 Mar 2020 14:59:49 +0800
+Subject: [PATCH] Export symbols of jsoncpp
+
+Signed-off-by: Liu, Kai1 <kai1.liu@intel.com>
+---
+ jsoncpp/BUILD.gn | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/jsoncpp/BUILD.gn b/jsoncpp/BUILD.gn
+index f2f48b9ee7c..b7603fa2d12 100644
+--- a/jsoncpp/BUILD.gn
++++ b/jsoncpp/BUILD.gn
+@@ -44,6 +44,9 @@ source_set("jsoncpp") {
+     "JSON_USE_NULLREF=0",
+   ]
+ 
++  configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
++  configs += [ "//build/config/gcc:symbol_visibility_default" ]
++
+   include_dirs = [ "source/src/lib_json" ]
+ 
+   if (!is_win || is_clang) {
+-- 
+2.17.1
+

--- a/talk/owt/patches/0001-Export-symbols-of-libyuv.patch
+++ b/talk/owt/patches/0001-Export-symbols-of-libyuv.patch
@@ -1,0 +1,26 @@
+From a59ad6fef977e98015a5ee2a0986e31e571fd06f Mon Sep 17 00:00:00 2001
+From: "Liu, Kai1" <kai1.liu@intel.com>
+Date: Tue, 10 Mar 2020 15:00:35 +0800
+Subject: [PATCH] Export symbols of libyuv
+
+Signed-off-by: Liu, Kai1 <kai1.liu@intel.com>
+---
+ BUILD.gn | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/BUILD.gn b/BUILD.gn
+index 8904fd6c..f8f41578 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -16,7 +16,7 @@ declare_args() {
+   # When building a shared library using a target in WebRTC or
+   # Chromium projects that depends on libyuv, setting this flag
+   # to true makes libyuv symbols visible inside that library.
+-  libyuv_symbols_visible = false
++  libyuv_symbols_visible = true
+ }
+ 
+ config("libyuv_config") {
+-- 
+2.17.1
+

--- a/talk/owt/sdk/base/customizedaudiodevicemodule.cc
+++ b/talk/owt/sdk/base/customizedaudiodevicemodule.cc
@@ -587,7 +587,7 @@ int CustomizedAudioDeviceModule::GetRecordAudioParameters(
 void CustomizedAudioDeviceModule::CreateOutputAdm(){
   if(_outputAdm==nullptr){
     _outputAdm = webrtc::AudioDeviceModuleImpl::Create(
-        AudioDeviceModule::kPlatformDefaultAudio, task_queue_factory_.get());
+        AudioDeviceModule::kDummyAudio, task_queue_factory_.get());
   }
 }
 }


### PR DESCRIPTION
We need to use dynamic library of libowt, so submit one patch.
The second patch is to fix adm init failure issue on server platform which has no audio device.