### PR TITLE
Don't compile functions not supported on iOS.

### DIFF
--- a/talk/owt/sdk/base/stream.cc
+++ b/talk/owt/sdk/base/stream.cc
@@ -366,6 +366,7 @@ std::shared_ptr<LocalStream> LocalStream::Create(
   return stream;
 }
 #endif
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
 std::shared_ptr<LocalStream> LocalStream::Create(
     std::shared_ptr<LocalCustomizedStreamParameters> parameters,
     std::unique_ptr<VideoFrameGeneratorInterface> framer) {
@@ -379,6 +380,8 @@ std::shared_ptr<LocalStream> LocalStream::Create(
   std::shared_ptr<LocalStream> stream(new LocalStream(parameters, encoder));
   return stream;
 }
+#endif
+
 LocalStream::LocalStream(const LocalCameraStreamParameters& parameters,
                          int& error_code) {
   if (!parameters.AudioEnabled() && !parameters.VideoEnabled()) {
@@ -526,6 +529,7 @@ LocalStream::LocalStream(
 }
 #endif
 
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
 LocalStream::LocalStream(
     std::shared_ptr<LocalCustomizedStreamParameters> parameters,
     std::unique_ptr<VideoFrameGeneratorInterface> framer) {
@@ -592,6 +596,7 @@ LocalStream::LocalStream(
   media_stream_ = stream;
   media_stream_->AddRef();
 }
+#endif
 RemoteStream::RemoteStream(MediaStreamInterface* media_stream,
                            const std::string& from)
     : origin_(from) {

--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -209,6 +209,7 @@ class LocalStream : public Stream {
       const bool is_audio_enabled,
       webrtc::VideoTrackSourceInterface* video_source,
       int& error_code);
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
   /**
     @brief Initialize a LocalCustomizedStream with parameters and frame
     generator.
@@ -237,6 +238,9 @@ class LocalStream : public Stream {
   static std::shared_ptr<LocalStream> Create(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
       VideoEncoderInterface* encoder);
+#endif
+
+#if defined(WEBRTC_WIN)
   /**
     @brief Initialize a local screen stream with parameters.
     @param parameters Parameters for creating the stream. The stream will
@@ -248,6 +252,7 @@ class LocalStream : public Stream {
   static std::shared_ptr<LocalStream> Create(
       std::shared_ptr<LocalDesktopStreamParameters> parameters,
       std::unique_ptr<LocalScreenStreamObserver> observer);
+#endif
 
  protected:
   explicit LocalStream(const LocalCameraStreamParameters& parameters,
@@ -255,17 +260,23 @@ class LocalStream : public Stream {
   explicit LocalStream(const bool is_audio_enabled,
                        webrtc::VideoTrackSourceInterface* video_source,
                        int& error_code);
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
   explicit LocalStream(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
       std::unique_ptr<VideoFrameGeneratorInterface> framer);
   explicit LocalStream(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
       VideoEncoderInterface* encoder);
+#endif
+#if defined(WEBRTC_WIN)
   explicit LocalStream(std::shared_ptr<LocalDesktopStreamParameters> parameters,
                        std::unique_ptr<LocalScreenStreamObserver> observer);
+#endif
 
  private:
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
   bool encoded_ = false;
+#endif
 #if defined(WEBRTC_MAC)
   std::unique_ptr<ObjcVideoCapturerInterface> capturer_;
 #endif


### PR DESCRIPTION
This PR fixes some undefined symbol errors on iOS.