### PR TITLE
Remove msdk dependency for D3D11 renderer

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -5,7 +5,7 @@ import("third_party/webrtc/webrtc.gni")
 group("default") {
   testonly = true
   deps = []
-  if (!is_linux && !is_win) {
+  if (!is_linux && !is_win && rtc_build_examples) {
     deps += [
       "//third_party/webrtc/examples",
     ]

--- a/DEPS
+++ b/DEPS
@@ -285,7 +285,7 @@ deps = {
     Var('chromium_git') + '/infra/luci/client-py.git' + '@' +  Var('swarming_revision'),
   # WebRTC-only dependencies (not present in Chromium).
   'src/third_party/webrtc':
-    Var('deps_webrtc_git') + '/owt-deps-webrtc' + '@' + '7c298ef33ad55f50117c2e4ab0b999e5afb0d745',
+    Var('deps_webrtc_git') + '/owt-deps-webrtc' + '@' + 'ecf03f9751c19600792d74548308a8bd972f3bbf',
  'src/third_party/accessibility_test_framework': {
       'packages': [
           {

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -72,4 +72,10 @@ declare_args() {
 
   # Some non-Chromium builds don't support building java targets.
   enable_java_templates = true
+
+  owt_gpra_lib_root = ""
+
+  owt_gpra_header_root = ""
+
+  owt_use_gpra = false
 }

--- a/build_overrides/webrtc.gni
+++ b/build_overrides/webrtc.gni
@@ -23,3 +23,6 @@ rtc_use_builtin_sw_codecs = true
 if (owt_include_tests) {
   rtc_include_tests = true
 }
+
+# By default disable protobuf
+rtc_enable_protobuf = false

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -53,21 +53,31 @@ if (!is_ios) {
       ":owt_sdk_base",
       ":owt_sdk_conf",
       ":owt_sdk_p2p",
-      "//third_party/protobuf:protobuf_lite",
       "//third_party/webrtc",
       "//third_party/webrtc:webrtc",
       "//third_party/webrtc/api:libjingle_peerconnection_api",
     ]
+
+    if (rtc_enable_protobuf) {
+      deps += [
+        "//third_party/protobuf:protobuf_lite",
+      ]
+    }
     complete_static_lib = true
   }
 }
 static_library("owt_sdk_base") {
   sources = [
+    "sdk/base/clock.cc",
     "sdk/base/cameravideocapturer.cc",
     "sdk/base/cameravideocapturer.h",
     "sdk/base/codecutils.cc",
     "sdk/base/codecutils.h",
     "sdk/base/deviceutils.cc",
+    "sdk/base/encodedstreamproviderwrapper.cc",
+    "sdk/base/encodedstreamproviderwrapper.h",
+    "sdk/base/encodedvideoencoderfactory.cc",
+    "sdk/base/encodedvideoencoderfactory.h",
     "sdk/base/eventtrigger.h",
     "sdk/base/exception.cc",
     "sdk/base/functionalobserver.cc",
@@ -90,6 +100,7 @@ static_library("owt_sdk_base") {
     "sdk/base/stringutils.h",
     "sdk/base/sysinfo.cc",
     "sdk/base/sysinfo.h",
+    "sdk/base/cursorutils.cc",
     "sdk/base/vcmcapturer.cc",
     "sdk/base/vcmcapturer.h",
     "sdk/base/webrtcaudiorendererimpl.cc",
@@ -113,8 +124,6 @@ static_library("owt_sdk_base") {
       "sdk/base/customizedvideoencoderproxy.h",
       "sdk/base/customizedvideosource.cc",
       "sdk/base/customizedvideosource.h",
-      "sdk/base/encodedvideoencoderfactory.cc",
-      "sdk/base/encodedvideoencoderfactory.h",
       "sdk/base/webrtcvideorendererimpl.cc",
       "sdk/base/webrtcvideorendererimpl.h",
       "sdk/include/cpp/owt/base/videodecoderinterface.h",
@@ -141,6 +150,7 @@ static_library("owt_sdk_base") {
     "//third_party/webrtc/system_wrappers:field_trial",
     "//third_party/webrtc/system_wrappers:metrics",
     "//third_party/webrtc/system_wrappers:system_wrappers",
+    "//third_party/ffmpeg:ffmpeg",
   ]
   deps = [
     "//base:logging_buildflags",
@@ -178,27 +188,42 @@ static_library("owt_sdk_base") {
     sources += [
       "sdk/base/desktopcapturer.cc",
       "sdk/base/desktopcapturer.h",
+      "sdk/base/win/d3dnativeframe.h",
+      "sdk/base/win/videorendererwin.cc",
+      "sdk/base/win/videorendererwin.h",
+      "sdk/base/windowcapturer.cc",
+      "sdk/base/windowcapturer.h",
+    ]
+  }
+  
+    if (owt_msdk_header_root != "") {
+    sources += [
+      "sdk/base/win/msdkvideodecoder.cc",
+      "sdk/base/win/msdkvideodecoder.h",
+      "sdk/base/win/msdkvideoencoder.cc",
+      "sdk/base/win/msdkvideoencoder.h",
+      "sdk/base/win/msdkvideodecoderfactory.cc",
+      "sdk/base/win/msdkvideodecoderfactory.h",
+      "sdk/base/win/msdkvideoencoderfactory.cc",
+      "sdk/base/win/msdkvideoencoderfactory.h",
       "sdk/base/win/base_allocator.cc",
       "sdk/base/win/base_allocator.h",
       "sdk/base/win/d3d_allocator.cc",
       "sdk/base/win/d3d_allocator.h",
-      "sdk/base/win/d3dnativeframe.h",
+      "sdk/base/win/d3d11_allocator.cc",
+      "sdk/base/win/d3d11_allocator.h",
+      "sdk/base/win/sysmem_allocator.h",
+      "sdk/base/win/sysmem_allocator.cc",
       "sdk/base/win/msdkvideobase.cc",
       "sdk/base/win/msdkvideobase.h",
-      "sdk/base/win/msdkvideodecoder.cc",
-      "sdk/base/win/msdkvideodecoder.h",
-      "sdk/base/win/msdkvideodecoderfactory.cc",
-      "sdk/base/win/msdkvideodecoderfactory.h",
-      "sdk/base/win/msdkvideoencoder.cc",
-      "sdk/base/win/msdkvideoencoder.h",
-      "sdk/base/win/msdkvideoencoderfactory.cc",
-      "sdk/base/win/msdkvideoencoderfactory.h",
-      "sdk/base/win/sysmem_allocator.cc",
-      "sdk/base/win/sysmem_allocator.h",
-      "sdk/base/win/videorendererwin.cc",
-      "sdk/base/win/videorendererwin.h",
-      "sdk/base/windowcapturer.cc",
+      "sdk/base/win/d3d11va_h264_decoder.cc",
+      "sdk/base/win/d3d11va_h264_decoder.h",
+      "sdk/base/win/d3d11device.cc",
+      "sdk/base/win/d3d11device.h",
+      "sdk/base/win/videorendererd3d11.cc",
+      "sdk/base/win/videorendererd3d11.h",
     ]
+    defines += [ "OWT_USE_MSDK" ]
   }
 
   if (!is_ios) {
@@ -209,7 +234,7 @@ static_library("owt_sdk_base") {
       "sdk/base/customizedvideodecoderproxy.h",
     ]
   }
-  if ((is_win || is_linux) && include_internal_audio_device) {
+  if (is_win || is_linux) {
     sources += [
       "sdk/base/customizedaudiocapturer.cc",
       "sdk/base/customizedaudiocapturer.h",

--- a/talk/owt/sdk/base/clock.cc
+++ b/talk/owt/sdk/base/clock.cc
@@ -1,0 +1,17 @@
+// Copyright (C) <2018> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "talk/owt/sdk/include/cpp/owt/base/clock.h"
+#include "webrtc/system_wrappers/include/clock.h"
+
+namespace owt {
+namespace base {
+
+Clock::Clock() : clock_(webrtc::Clock::GetRealTimeClock()) {}
+
+int64_t Clock::TimeInMilliseconds() {
+  return clock_->TimeInMilliseconds();
+}
+
+}  // namespace base
+}  // namespace owt

--- a/talk/owt/sdk/base/cursorutils.cc
+++ b/talk/owt/sdk/base/cursorutils.cc
@@ -1,0 +1,61 @@
+// Copyright (C) <2018> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "talk/owt/sdk/include/cpp/owt/base/cursorutils.h"
+#include "webrtc/rtc_base/strings/json.h"
+#include "webrtc/rtc_base/third_party/base64/base64.h"
+
+namespace owt {
+namespace base {
+// Format is:
+//  {visible: true, colored: true, framePos: {x, y}, hotspot: {x, y},
+//     srcRect: {left: x, top: y, right: z, bottom: v},
+//     dstRect: {left: x, top: y, right: z, bottom: v},
+//     width: x,  height: y, pitch: z,
+//     cursorData: xxxxxxxxxxxxxx}  //base64 encoded data.
+std::string CursorUtils::GetJsonForCursorInfo(CursorInfo& cursor_info) {
+  std::string result;
+  Json::Value root, src, dst, frame_pos, hotspot;
+
+  Json::StyledWriter styled_writer;
+
+  // If invisible, only send "invisible"
+  if (!cursor_info.visible) {
+    root["visible"] = false;
+    root["type"] = "cursor";
+    result = styled_writer.write(root);
+    return result;
+  }
+  root["type"] = "cursor";
+  root["visible"] = cursor_info.visible;
+  root["colored"] = cursor_info.colored;
+  frame_pos.append(static_cast<int> (cursor_info.frame_pos.x));
+  frame_pos.append(static_cast<int> (cursor_info.frame_pos.y));
+  root["framePos"] = frame_pos;
+  hotspot.append(static_cast<int> (cursor_info.hotspot.x));
+  hotspot.append(static_cast<int> (cursor_info.hotspot.y));
+  root["hotspot"] = hotspot;
+  src["left"] = static_cast<int>(cursor_info.src_rect.left);
+  src["top"] = static_cast<int>(cursor_info.src_rect.top);
+  src["right"] = static_cast<int>(cursor_info.src_rect.right);
+  src["bottom"] = static_cast<int>(cursor_info.src_rect.bottom);
+  root["srcRect"] = src;
+  dst["left"] = static_cast<int>(cursor_info.dst_rect.left);
+  dst["top"] = static_cast<int>(cursor_info.dst_rect.top);
+  dst["right"] = static_cast<int>(cursor_info.dst_rect.right);
+  dst["bottom"] = static_cast<int>(cursor_info.dst_rect.bottom);
+  root["dstRect"] = dst;
+  root["width"] = static_cast<int>(cursor_info.width);
+  root["height"] = static_cast<int>(cursor_info.height);
+  root["pitch"] = static_cast<int>(cursor_info.pitch);
+
+  std::string base64_encoded;
+  rtc::Base64::EncodeFromArray(cursor_info.cursor_buffer,
+                               cursor_info.pitch * cursor_info.height,
+                               &base64_encoded);
+  root["cursorData"] = base64_encoded;
+  result = styled_writer.write(root);
+  return result;
+}
+}  // namespace base
+}  // namespace owt

--- a/talk/owt/sdk/base/customizedaudiodevicemodule.cc
+++ b/talk/owt/sdk/base/customizedaudiodevicemodule.cc
@@ -16,6 +16,7 @@
 #include "webrtc/modules/audio_device/audio_device_impl.h"
 #include "talk/owt/sdk/base/customizedaudiocapturer.h"
 #include "talk/owt/sdk/base/customizedaudiodevicemodule.h"
+#include "webrtc/modules/audio_device/include/fake_audio_device.h"
 
 // Code partly borrowed from WebRTC project's audio device moudule implementation.
 #define CHECK_INITIALIZED() \
@@ -584,10 +585,16 @@ int CustomizedAudioDeviceModule::GetRecordAudioParameters(
   return _ptrAudioDevice->GetRecordAudioParameters(params);
 }
 #endif  // WEBRTC_IOS
-void CustomizedAudioDeviceModule::CreateOutputAdm(){
-  if(_outputAdm==nullptr){
+
+void CustomizedAudioDeviceModule::CreateOutputAdm() {
+  if (_outputAdm == nullptr) {
+#if defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
     _outputAdm = webrtc::AudioDeviceModuleImpl::Create(
         AudioDeviceModule::kPlatformDefaultAudio, task_queue_factory_.get());
+#endif
+    if (_outputAdm == nullptr) {
+      _outputAdm = new rtc::RefCountedObject<webrtc::FakeAudioDeviceModule>();
+    }
   }
 }
 }

--- a/talk/owt/sdk/base/customizedaudiodevicemodule.h
+++ b/talk/owt/sdk/base/customizedaudiodevicemodule.h
@@ -4,7 +4,7 @@
 #ifndef OWT_BASE_CUSTOMIZEDAUDIODEVICEMODULE_H_
 #define OWT_BASE_CUSTOMIZEDAUDIODEVICEMODULE_H_
 
-#if defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
+//#if defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
 #include <memory>
 #include "webrtc/api/task_queue/default_task_queue_factory.h"
 #include "webrtc/api/scoped_refptr.h"
@@ -129,5 +129,5 @@ class CustomizedAudioDeviceModule : public webrtc::AudioDeviceModule {
 };
 }
 }
-#endif  // defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
+//#endif  // defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
 #endif  // OWT_BASE_CUSTOMIZEDAUDIODEVICEMODULE_H_

--- a/talk/owt/sdk/base/customizedencoderbufferhandle.h
+++ b/talk/owt/sdk/base/customizedencoderbufferhandle.h
@@ -20,6 +20,38 @@ class CustomizedEncoderBufferHandle{
   uint32_t bitrate_kbps;
   virtual ~CustomizedEncoderBufferHandle() {}
 };
+
+class CustomizedEncoderBufferHandle2 {
+ public:
+  CustomizedEncoderBufferHandle2()
+      : encoder_event_callback_(nullptr),
+        width_(0),
+        height_(0),
+        fps_(0),
+        bitrate_kbps_(0),
+        buffer_(nullptr),
+        buffer_length_(0) {}
+
+  virtual ~CustomizedEncoderBufferHandle2() {
+    if (buffer_ != nullptr) {
+      delete[] buffer_;
+      buffer_ = nullptr;
+    }
+    encoder_event_callback_ = nullptr;
+  }
+
+ public:
+  EncoderEventCallback* encoder_event_callback_;
+  size_t width_;
+  size_t height_;
+  uint32_t fps_;
+  uint32_t bitrate_kbps_;
+  uint8_t* buffer_;
+  size_t buffer_length_;
+  EncodedImageMetaData meta_data_;
+};
+
+// Deprecated.
 class EncodedFrameBuffer : public VideoFrameBuffer {
  public:
   EncodedFrameBuffer(CustomizedEncoderBufferHandle* native_handle)
@@ -45,6 +77,36 @@ class EncodedFrameBuffer : public VideoFrameBuffer {
   void* native_handle() { return native_handle_; }
  private:
   CustomizedEncoderBufferHandle* native_handle_;
+  size_t width_;
+  size_t height_;
+};
+
+class EncodedFrameBuffer2 : public VideoFrameBuffer {
+ public:
+  EncodedFrameBuffer2(CustomizedEncoderBufferHandle2* native_handle)
+      : native_handle_(native_handle) {
+    if (native_handle) {
+      width_ = native_handle->width_;
+      height_ = native_handle->height_;
+    }
+  }
+  virtual ~EncodedFrameBuffer2() {
+    if (native_handle_) {
+      delete native_handle_;
+      native_handle_ = nullptr;
+    }
+  }
+  Type type() const override { return Type::kNative; }
+  int width() const override { return width_; }
+  int height() const override { return height_; }
+  rtc::scoped_refptr<I420BufferInterface> ToI420() override {
+    RTC_NOTREACHED();
+    return nullptr;
+  }
+  void* native_handle() { return native_handle_; }
+
+ private:
+  CustomizedEncoderBufferHandle2* native_handle_;
   size_t width_;
   size_t height_;
 };

--- a/talk/owt/sdk/base/customizedframescapturer.cc
+++ b/talk/owt/sdk/base/customizedframescapturer.cc
@@ -1,7 +1,7 @@
 // Copyright (C) <2018> Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
-
+#include <algorithm>
 #include "webrtc/common_video/include/video_frame_buffer.h"
 #include "webrtc/media/base/video_common.h"
 #include "webrtc/rtc_base/logging.h"
@@ -80,13 +80,16 @@ CustomizedFramesCapturer::CustomizedFramesCapturer(
       bitrate_kbps_(0),
       frame_type_(frame_generator_->GetType()),
       frame_buffer_capacity_(0),
-      frame_buffer_(nullptr) {}
+      frame_buffer_(nullptr) {
+  encoded_stream_provider_wrapper_ = nullptr;
+  encoder_event_callback_ = nullptr;
+}
 CustomizedFramesCapturer::CustomizedFramesCapturer(
     int width,
     int height,
     int fps,
     int bitrate_kbps,
-    VideoEncoderInterface* encoder)
+    std::shared_ptr<EncodedStreamProvider> encoder)
     : frame_generator_(nullptr),
       encoder_(encoder),
       width_(width),
@@ -94,7 +97,15 @@ CustomizedFramesCapturer::CustomizedFramesCapturer(
       fps_(fps),
       bitrate_kbps_(bitrate_kbps),
       frame_buffer_capacity_(0),
-      frame_buffer_(nullptr) {}
+      frame_buffer_(nullptr) {
+  if (encoder.get()) {
+    encoded_stream_provider_wrapper_.reset(
+        new EncodedStreamProviderWrapper(encoder));
+  } else {
+    encoded_stream_provider_wrapper_ = nullptr;
+  }
+  encoder_event_callback_ = nullptr;	  
+}
 CustomizedFramesCapturer::~CustomizedFramesCapturer() {
   DeRegisterCaptureDataCallback();
   StopCapture();
@@ -103,6 +114,10 @@ CustomizedFramesCapturer::~CustomizedFramesCapturer() {
   // application. mark it to nullptr to avoid ReadFrame
   // passing native buffer to stack.
   encoder_ = nullptr;
+    if (encoder_event_callback_ != nullptr) {
+    delete encoder_event_callback_;
+    encoder_event_callback_ = nullptr;
+  }
 }
 
 void CustomizedFramesCapturer::RegisterCaptureDataCallback(
@@ -132,6 +147,13 @@ int32_t CustomizedFramesCapturer::StartCapture(
       return -1;
     }
   }
+  if (encoded_stream_provider_wrapper_ != nullptr) {
+    encoded_stream_provider_wrapper_->AddSink(this);
+    if (encoder_event_callback_ == nullptr)
+      encoder_event_callback_ =
+          new EncoderEventCallbackWrapper(encoded_stream_provider_wrapper_);
+    encoder_event_callback_->StartStreaming();
+  }
   capture_started_ = true;
   return 0;
 }
@@ -144,6 +166,13 @@ int32_t CustomizedFramesCapturer::StopCapture() {
     }
     frames_generator_thread_->Quit();
     frames_generator_thread_.reset();
+  }
+  if (encoded_stream_provider_wrapper_ != nullptr) {
+    encoded_stream_provider_wrapper_->RemoveSink();
+  }
+
+  if (encoder_event_callback_ != nullptr) {
+    encoder_event_callback_->StopStreaming();
   }
   capture_started_ = false;
   return 0;
@@ -167,6 +196,45 @@ int32_t CustomizedFramesCapturer::SetCaptureRotation(
     webrtc::VideoRotation rotation) {
   // Not implemented.
   return 0;
+}
+
+void CustomizedFramesCapturer::OnStreamProviderFrame(
+    const std::vector<uint8_t>& buffer,
+    const EncodedImageMetaData& meta_data) {
+  if (buffer.size() == 0)
+    return;
+
+  CustomizedEncoderBufferHandle2* encoder_context =
+      new CustomizedEncoderBufferHandle2;
+  encoder_context->encoder_event_callback_ = encoder_event_callback_;
+  encoder_context->width_ = width_;
+  encoder_context->height_ = height_;
+  encoder_context->fps_ = fps_;
+  encoder_context->bitrate_kbps_ = bitrate_kbps_;
+  encoder_context->meta_data_.capture_timestamp = meta_data.capture_timestamp;
+  encoder_context->meta_data_.encoding_end = meta_data.encoding_end;
+  encoder_context->meta_data_.encoding_start = meta_data.encoding_start;
+  encoder_context->meta_data_.last_fragment = meta_data.last_fragment;
+  encoder_context->meta_data_.picture_id = meta_data.picture_id;
+  if (meta_data.encoded_image_sidedata_size() > 0) {
+    encoder_context->meta_data_.encoded_image_sidedata_new(
+        meta_data.encoded_image_sidedata_size());
+    memcpy(encoder_context->meta_data_.encoded_image_sidedata_get(),
+           meta_data.encoded_image_sidedata_get(),
+           meta_data.encoded_image_sidedata_size());
+    // sidedata will be freed by encoder proxy.
+  }
+  uint8_t* frame_buffer = new uint8_t[buffer.size()];
+  std::copy(buffer.begin(), buffer.end(), frame_buffer);
+
+  encoder_context->buffer_ = frame_buffer;
+  encoder_context->buffer_length_ = buffer.size();
+
+  rtc::scoped_refptr<owt::base::EncodedFrameBuffer2> rtc_buffer =
+      new rtc::RefCountedObject<owt::base::EncodedFrameBuffer2>(encoder_context);
+  webrtc::VideoFrame pending_frame(rtc_buffer, 0, rtc::TimeMillis(),
+                                   webrtc::kVideoRotation_0);
+  data_callback_->OnFrame(pending_frame);
 }
 
 int CustomizedFramesCapturer::I420DataSize(int height,
@@ -221,29 +289,8 @@ void CustomizedFramesCapturer::ReadFrame() {
 
     capture_frame.set_ntp_time_ms(0);
     data_callback_->OnFrame(capture_frame);
-  } else if (encoder_ != nullptr) {  // video encoder interface used. Pass the
-                                     // encoder information.
-    CustomizedEncoderBufferHandle* encoder_context =
-        new CustomizedEncoderBufferHandle;
-    encoder_context->encoder = encoder_;
-    encoder_context->width = width_;
-    encoder_context->height = height_;
-    encoder_context->fps = fps_;
-    encoder_context->bitrate_kbps = bitrate_kbps_;
-    rtc::scoped_refptr<owt::base::EncodedFrameBuffer> buffer =
-        new rtc::RefCountedObject<owt::base::EncodedFrameBuffer>(
-            encoder_context);
-
-    webrtc::VideoFrame pending_frame =
-        webrtc::VideoFrame::Builder()
-            .set_video_frame_buffer(buffer)
-            .set_timestamp_rtp(0)
-            .set_timestamp_ms(rtc::TimeMillis())
-            .set_rotation(webrtc::kVideoRotation_0)
-            .build();
-
-    pending_frame.set_ntp_time_ms(0);
-    data_callback_->OnFrame(pending_frame);
+  } else {
+    // For encoded input, we use push mode so it will not be delivered in capture thread.
   }
 }
 }  // namespace base

--- a/talk/owt/sdk/base/customizedvideoencoderproxy.h
+++ b/talk/owt/sdk/base/customizedvideoencoderproxy.h
@@ -38,7 +38,10 @@ class CustomizedVideoEncoderProxy : public webrtc::VideoEncoder {
   // int count_;
   webrtc::VideoCodecType codec_type_;
   uint16_t picture_id_;
-  VideoEncoderInterface* external_encoder_;
+  EncoderEventCallback* encoder_event_callback_ = nullptr;
+  uint32_t last_timestamp_;
+  uint64_t last_capture_timestamp_;
+  bool update_ts_ = true;
 };
 }
 }

--- a/talk/owt/sdk/base/customizedvideosource.cc
+++ b/talk/owt/sdk/base/customizedvideosource.cc
@@ -19,7 +19,7 @@ CustomizedVideoCapturerFactory::Create(
 rtc::scoped_refptr<webrtc::VideoCaptureModule>
 CustomizedVideoCapturerFactory::Create(
     std::shared_ptr<LocalCustomizedStreamParameters> parameters,
-    VideoEncoderInterface* encoder) {
+    std::shared_ptr<EncodedStreamProvider> encoder) {
   return new rtc::RefCountedObject<CustomizedFramesCapturer>(
       parameters->ResolutionWidth(), parameters->ResolutionHeight(),
       parameters->Fps(), parameters->Bitrate(), encoder);
@@ -83,7 +83,7 @@ CustomizedVideoCapturerFactory::Create(
 
   CustomizedCapturer* CustomizedCapturer::Create(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
-      VideoEncoderInterface * encoder) {
+      std::shared_ptr<EncodedStreamProvider> encoder) {
     std::unique_ptr<CustomizedCapturer> vcm_capturer(new CustomizedCapturer());
     if (!vcm_capturer->Init(parameters, encoder))
       return nullptr;
@@ -130,7 +130,7 @@ CustomizedVideoCapturerFactory::Create(
 
   bool CustomizedCapturer::Init(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
-      VideoEncoderInterface * encoder) {
+      std::shared_ptr<EncodedStreamProvider> encoder) {
     vcm_ = CustomizedVideoCapturerFactory::Create(parameters, encoder);
 
     if (!vcm_)

--- a/talk/owt/sdk/base/customizedvideosource.h
+++ b/talk/owt/sdk/base/customizedvideosource.h
@@ -32,7 +32,7 @@ class CustomizedVideoCapturerFactory {
       std::unique_ptr<VideoFrameGeneratorInterface> framer);
   static rtc::scoped_refptr<webrtc::VideoCaptureModule> Create(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
-      VideoEncoderInterface* encoder);
+      std::shared_ptr<EncodedStreamProvider> encoder);
 #if defined(WEBRTC_WIN)
   static rtc::scoped_refptr<webrtc::VideoCaptureModule> Create(
       std::shared_ptr<LocalDesktopStreamParameters> parameters,
@@ -70,7 +70,7 @@ class CustomizedCapturer : public CustomizedVideoSource,
       std::unique_ptr<VideoFrameGeneratorInterface> framer);
   static CustomizedCapturer* Create(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
-      VideoEncoderInterface* encoder);
+      std::shared_ptr<EncodedStreamProvider> encoder);
 #if defined(WEBRTC_WIN)
   static CustomizedCapturer* Create(
       std::shared_ptr<LocalDesktopStreamParameters> parameters,
@@ -86,7 +86,7 @@ class CustomizedCapturer : public CustomizedVideoSource,
   bool Init(std::shared_ptr<LocalCustomizedStreamParameters> parameters,
             std::unique_ptr<VideoFrameGeneratorInterface> framer);
   bool Init(std::shared_ptr<LocalCustomizedStreamParameters> parameters,
-            VideoEncoderInterface* encoder);
+            std::shared_ptr<EncodedStreamProvider> encoder);
 #if defined(WEBRTC_WIN)
   bool Init(std::shared_ptr<LocalDesktopStreamParameters> parameters,
             std::unique_ptr<LocalScreenStreamObserver> observer);
@@ -159,7 +159,7 @@ class LocalEncodedCaptureTrackSource : public webrtc::VideoTrackSource {
  public:
   static rtc::scoped_refptr<LocalEncodedCaptureTrackSource> Create(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
-      VideoEncoderInterface* encoder) {
+      std::shared_ptr<EncodedStreamProvider> encoder) {
     std::unique_ptr<CustomizedCapturer> capturer;
     capturer =
         absl::WrapUnique(CustomizedCapturer::Create(parameters, encoder));

--- a/talk/owt/sdk/base/encodedstreamproviderwrapper.cc
+++ b/talk/owt/sdk/base/encodedstreamproviderwrapper.cc
@@ -1,0 +1,142 @@
+// Copyright (C) <2018> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include "talk/owt/sdk/base/encodedstreamproviderwrapper.h"
+
+namespace owt {
+namespace base {
+
+EncodedStreamProviderWrapper::EncodedStreamProviderWrapper(
+    std::shared_ptr<EncodedStreamProvider> encoded_stream_provider)
+      : encoded_stream_provider_(encoded_stream_provider) {
+}
+
+void EncodedStreamProviderWrapper::RequestKeyFrame() {
+  auto that = encoded_stream_provider_.lock();
+
+  if (that != nullptr) {
+    that->RequestKeyFrame();
+  }
+}
+
+void EncodedStreamProviderWrapper::RequestRateUpdate(uint64_t bitrate_bps,
+                                                     uint32_t frame_rate) {
+  auto that = encoded_stream_provider_.lock();
+
+  if (that != nullptr) {
+    that->RequestRateUpdate(bitrate_bps, frame_rate);
+  }
+}
+
+void EncodedStreamProviderWrapper::AddSink(EncodedStreamProviderSink* sink) {
+  auto that = encoded_stream_provider_.lock();
+
+  if (that != nullptr) {
+    that->AddSink(sink);
+  }
+}
+
+void EncodedStreamProviderWrapper::RemoveSink() {
+  auto that = encoded_stream_provider_.lock();
+
+  if (that != nullptr) {
+    that->RemoveSink();
+  }
+}
+
+void EncodedStreamProviderWrapper::Start() {
+  auto that = encoded_stream_provider_.lock();
+
+  if (that != nullptr) {
+    that->StartStreaming();
+  }
+}
+
+void EncodedStreamProviderWrapper::Stop() {
+  auto that = encoded_stream_provider_.lock();
+
+  if (that != nullptr) {
+    that->StopStreaming();
+  }
+}
+
+std::shared_ptr<EncodedStreamProvider> EncodedStreamProvider::Create() {
+  return std::shared_ptr<EncodedStreamProvider>(new EncodedStreamProvider);
+}
+
+void EncodedStreamProvider::SendOneFrame(const std::vector<uint8_t>& buffer,
+  const EncodedImageMetaData& meta_data) {
+  if (sink_ != nullptr) {
+    sink_->OnStreamProviderFrame(buffer, meta_data);
+  }
+}
+
+void EncodedStreamProvider::RequestKeyFrame() {
+  for (auto its = stream_provider_observers_.begin();
+       its != stream_provider_observers_.end(); ++its) {
+    (*its).get().OnKeyFrameRequest();
+  }
+}
+
+void EncodedStreamProvider::RequestRateUpdate(uint64_t bitrate_bps,
+  uint32_t frame_rate) {
+  for (auto its = stream_provider_observers_.begin();
+       its != stream_provider_observers_.end(); ++its) {
+    (*its).get().OnRateUpdate(bitrate_bps, frame_rate);
+  }
+}
+
+void EncodedStreamProvider::StartStreaming() {
+  streaming_started_ = true;
+  for (auto its = stream_provider_observers_.begin();
+       its != stream_provider_observers_.end(); ++its) {
+    (*its).get().OnStarted();
+  }
+}
+
+void EncodedStreamProvider::StopStreaming() {
+  streaming_started_ = false;
+  for (auto its = stream_provider_observers_.begin();
+       its != stream_provider_observers_.end(); ++its) {
+    (*its).get().OnStopped();
+  }
+}
+
+void EncodedStreamProvider::AddSink(EncodedStreamProviderSink* sink) {
+  sink_ = sink;
+}
+
+void EncodedStreamProvider::RemoveSink() {
+  sink_ = nullptr;
+}
+
+void EncodedStreamProvider::DeRegisterEncoderObserver(EncoderObserver& observer) {
+  const std::lock_guard<std::mutex> lock(observer_mutex_);
+  auto it = std::find_if(
+      stream_provider_observers_.begin(), stream_provider_observers_.end(),
+      [&](std::reference_wrapper<EncoderObserver> o) -> bool {
+        return &observer == &(o.get());
+      });
+
+  if (it != stream_provider_observers_.end())
+    stream_provider_observers_.erase(it);
+}
+
+void EncodedStreamProvider::RegisterEncoderObserver(EncoderObserver& observer) {
+  const std::lock_guard<std::mutex> lock(observer_mutex_);
+  std::vector<std::reference_wrapper<EncoderObserver>>::iterator it =
+      std::find_if(stream_provider_observers_.begin(),
+                   stream_provider_observers_.end(),
+                   [&](std::reference_wrapper<EncoderObserver> o) -> bool {
+                     return &observer == &(o.get());
+                   });
+  if (it != stream_provider_observers_.end()) {
+    return;
+  }
+  stream_provider_observers_.push_back(observer);
+}
+
+}
+}

--- a/talk/owt/sdk/base/encodedstreamproviderwrapper.h
+++ b/talk/owt/sdk/base/encodedstreamproviderwrapper.h
@@ -1,0 +1,81 @@
+// Copyright (C) <2018> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OWT_BASE_ENCODEDSTREAMPROVIDERWRAPPER_H_
+#define OWT_BASE_ENCODEDSTREAMPROVIDERWRAPPER_H_
+
+#include <memory>
+#include "owt/base/videoencoderinterface.h"
+
+namespace owt {
+namespace base {
+
+/// EncodedStreamProviderWrapper is a wrapper class
+/// for EncodedStreamProvider, to facilitate customizedcapturer
+/// interaction with it. 
+class EncodedStreamProviderWrapper : public std::enable_shared_from_this<EncodedStreamProviderWrapper> {
+ public:
+  EncodedStreamProviderWrapper(
+      std::shared_ptr<EncodedStreamProvider> encoded_stream_provider);
+
+  // The wrapper does not SendOneFrame API application will interact with underlying provider directly.
+  void RequestKeyFrame();
+
+  void RequestRateUpdate(uint64_t bitrate_bps, uint32_t frame_rate);
+
+  void Start();
+
+  void Stop(); 
+
+  void AddSink(EncodedStreamProviderSink* sink);
+
+  void RemoveSink();
+
+ private:
+  std::weak_ptr<EncodedStreamProvider> encoded_stream_provider_;
+};
+
+// Callback object that will be passed to owt customized encoder proxy via native handle.
+class EncoderEventCallbackWrapper : public EncoderEventCallback {
+ public:
+  EncoderEventCallbackWrapper(
+      std::shared_ptr<EncodedStreamProviderWrapper> provider_wrapper)
+      : provider_wrapper_(provider_wrapper) {}
+
+  virtual ~EncoderEventCallbackWrapper() {}
+
+  void RequestKeyFrame() {
+    auto that = provider_wrapper_.lock();
+    if (that) {
+      that->RequestKeyFrame();
+    }
+  }
+
+  void RequestRateUpdate(uint64_t bitrate_bps, uint32_t frame_rate) {
+    auto that = provider_wrapper_.lock();
+    if (that) {
+     that->RequestRateUpdate(bitrate_bps, frame_rate);
+    }
+  }
+
+  void StartStreaming() {
+    auto that = provider_wrapper_.lock();
+    if (that) {
+      that->Start();
+    }
+  }
+
+  void StopStreaming() { 
+    auto that = provider_wrapper_.lock();
+    if (that) {
+      that->Stop();
+    }
+  }
+ private:
+  std::weak_ptr<EncodedStreamProviderWrapper> provider_wrapper_;
+};
+}  // namespace base
+}  // namespace owt
+
+#endif

--- a/talk/owt/sdk/base/encodedvideoencoderfactory.cc
+++ b/talk/owt/sdk/base/encodedvideoencoderfactory.cc
@@ -38,9 +38,11 @@ EncodedVideoEncoderFactory::CreateVideoEncoder(
 std::vector<webrtc::SdpVideoFormat>
 EncodedVideoEncoderFactory::GetSupportedFormats() const {
   std::vector<webrtc::SdpVideoFormat> supported_codecs;
+#if 0
   supported_codecs.push_back(webrtc::SdpVideoFormat(cricket::kVp8CodecName));
   for (const webrtc::SdpVideoFormat& format : webrtc::SupportedVP9Codecs())
     supported_codecs.push_back(format);
+#endif
   // TODO: We should combine the codec profiles that hardware H.264 encoder
   // supports with those provided by built-in H.264 encoder
   for (const webrtc::SdpVideoFormat& format : owt::base::CodecUtils::SupportedH264Codecs())

--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -7,12 +7,22 @@ namespace base {
 #if defined(WEBRTC_WIN)
 // Enable hardware acceleration by default is on.
 bool GlobalConfiguration::hardware_acceleration_enabled_ = true;
+ID3D11Device* GlobalConfiguration::d3d11_decoding_device_ = nullptr;
 #endif
+int GlobalConfiguration::link_mtu_ = 0; // not set;
+int GlobalConfiguration::min_port_ = 0; // not set;
+int GlobalConfiguration::max_port_ = 0; // not set;
+bool GlobalConfiguration::low_latency_streaming_enabled_ = false;
+bool GlobalConfiguration::log_latency_to_file_enabled_ = false;
 bool GlobalConfiguration::encoded_frame_ = false;
+
+int GlobalConfiguration::delay_based_bwe_weight_ = 0;
 std::unique_ptr<AudioFrameGeneratorInterface>
     GlobalConfiguration::audio_frame_generator_ = nullptr;
+#if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
 std::unique_ptr<VideoDecoderInterface>
     GlobalConfiguration::video_decoder_ = nullptr;
+#endif
 int GlobalConfiguration::h264_temporal_layers_ = 1;
 #if defined(WEBRTC_IOS)
 AudioProcessingSettings GlobalConfiguration::audio_processing_settings_ = {

--- a/talk/owt/sdk/base/peerconnectionchannel.h
+++ b/talk/owt/sdk/base/peerconnectionchannel.h
@@ -136,6 +136,7 @@ class PeerConnectionChannel : public rtc::MessageHandler,
   // Use a map if we need more than one data channels for a PeerConnection in
   // the future.
   rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel_;
+  rtc::scoped_refptr<webrtc::DataChannelInterface> control_data_channel_;
   webrtc::MediaConstraints media_constraints_;
   // Direction of audio and video transceivers. In conference mode, there are at
   // most 1 audio transceiver and 1 video transceiver.

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.h
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.h
@@ -8,6 +8,8 @@
 #include "webrtc/api/media_stream_interface.h"
 #include "webrtc/sdk/media_constraints.h"
 #include "webrtc/rtc_base/bind.h"
+#include "webrtc/rtc_base/network.h"
+#include "webrtc/p2p/base/basic_packet_socket_factory.h"
 namespace owt {
 namespace base {
 using webrtc::MediaStreamInterface;
@@ -91,6 +93,8 @@ class PeerConnectionDependencyFactory : public rtc::RefCountInterface {
   rtc::NetworkMonitorInterface* network_monitor_;
 #endif
   std::string field_trial_;
+  std::shared_ptr<rtc::BasicNetworkManager> network_manager_;
+  std::shared_ptr<rtc::BasicPacketSocketFactory> packet_socket_factory_;
 };
 }
 }  // namespace owt

--- a/talk/owt/sdk/base/sdputils.cc
+++ b/talk/owt/sdk/base/sdputils.cc
@@ -58,6 +58,74 @@ std::string SdpUtils::SetPreferVideoCodecs(const std::string& original_sdp,
   cur_sdp = SdpUtils::SetPreferCodecs(cur_sdp, codec_names, false);
   return cur_sdp;
 }
+
+std::string SdpUtils::SetStartVideoBandwidth(const std::string& sdp,
+                                             int bandwidth) {
+  std::regex reg_red_codec("a=rtpmap:(\\d+) red\\/\\d+[\r]?[\n]?",
+                           std::regex_constants::icase);
+  std::smatch fmtp_map_match;
+  std::string red_codec;
+  auto search_result = std::regex_search(sdp, fmtp_map_match, reg_red_codec);
+  if (search_result && fmtp_map_match.size() > 0) {
+    red_codec = fmtp_map_match[1];
+  }
+
+  std::regex reg_video("m=video .*? ([0-9 ]+)[\r]?[\n]?",
+                       std::regex_constants::icase);
+  search_result = std::regex_search(sdp, fmtp_map_match, reg_video);
+  if (!search_result && fmtp_map_match.size() == 0) {
+    return sdp;
+  }
+  std::string str = fmtp_map_match[1];
+  int start = 0;
+  std::string delim = " ";
+  size_t idx = str.find(delim, start);
+  std::string ret_str = sdp;
+  std::string reg_start_replace = "(a=fmtp:";
+  std::string reg_end_replace = ")";
+  std::string to_replace =
+      "$1 x-google-start-bitrate=" + std::to_string(bandwidth);
+  std::string reg_start_insert = "(a=rtpmap:(";
+  std::string reg_end_insert = ") .*[\r]?[\n]?)";
+  std::string to_insert =
+      "$1a=fmtp:$2 x-google-start-bitrate=" + std::to_string(bandwidth) + "\n";
+  std::regex reg_fmtp_video;
+  std::string sub_str = "";
+  while (idx != std::string::npos) {
+    sub_str = str.substr(start, idx - start);
+    start = idx + delim.size();
+    idx = str.find(delim, start);
+    if (sub_str.compare(red_codec) == 0) {
+      continue;
+    }
+    reg_fmtp_video.assign(reg_start_replace + sub_str + reg_end_replace,
+                          std::regex_constants::icase);
+    search_result = std::regex_search(ret_str, fmtp_map_match, reg_fmtp_video);
+    if (!search_result && fmtp_map_match.size() == 0) {
+      reg_fmtp_video.assign(reg_start_insert + sub_str + reg_end_insert,
+                            std::regex_constants::icase);
+      ret_str = std::regex_replace(ret_str, reg_fmtp_video, to_insert);
+    } else {
+      ret_str = std::regex_replace(ret_str, reg_fmtp_video, to_replace);
+    }
+  }
+  sub_str = str.substr(start);
+  if (sub_str.compare(red_codec) == 0) {
+    return ret_str;
+  }
+  reg_fmtp_video.assign(reg_start_replace + sub_str + reg_end_replace,
+                        std::regex_constants::icase);
+  search_result = std::regex_search(ret_str, fmtp_map_match, reg_fmtp_video);
+  if (!search_result && fmtp_map_match.size() == 0) {
+    reg_fmtp_video.assign(reg_start_insert + sub_str + reg_end_insert,
+                          std::regex_constants::icase);
+    ret_str = std::regex_replace(ret_str, reg_fmtp_video, to_insert);
+  } else {
+    ret_str = std::regex_replace(ret_str, reg_fmtp_video, to_replace);
+  }
+  return ret_str;
+}
+
 std::vector<std::string> SdpUtils::GetCodecValues(const std::string& sdp,
     std::string& codec_name,
     bool is_audio) {
@@ -96,7 +164,7 @@ std::string SdpUtils::SetPreferCodecs(const std::string& sdp,
   std::vector<std::string> kept_codec_values;
   if (!is_audio) {
     // Get red and ulpfec payload type if any.
-    bool has_red = false, has_ulpfec = false;
+    bool has_red = false, has_ulpfec = false, has_flexfec = false;
     std::regex reg_red_map(
         "a=rtpmap:(\\d+) red\\/\\d+(?=[\r]?[\n]?)",
         std::regex_constants::icase);
@@ -117,6 +185,15 @@ std::string SdpUtils::SetPreferCodecs(const std::string& sdp,
       ulpfec_codec_value = ulpfec_map_match[1];
       has_ulpfec = true;
     }
+    std::regex reg_flexfec_map("a=rtpmap:(\\d+) flexfec-03\\/\\d+(?=[\r]?[\n]?)",
+                           std::regex_constants::icase);
+    std::smatch flexfec_map_match;
+    std::string flexfec_codec_value;
+    search_result = std::regex_search(sdp, flexfec_map_match, reg_flexfec_map);
+    if (search_result && flexfec_map_match.size() != 0) {
+      flexfec_codec_value = flexfec_map_match[1];
+      has_flexfec = true;
+    }
     if (has_red) {
       kept_codec_values.push_back(red_codec_value);
       for (auto& rtx_value : rtx_maps) {
@@ -132,6 +209,10 @@ std::string SdpUtils::SetPreferCodecs(const std::string& sdp,
             kept_codec_values.push_back(rtx_value.first);
         }
       }
+    }
+    if (has_flexfec) {
+      kept_codec_values.push_back(flexfec_codec_value);
+      // flex-fec does not involve rtx so we don't search its rtx association.
     }
   }
   for (auto& codec_name : codec_names) {

--- a/talk/owt/sdk/base/sdputils.h
+++ b/talk/owt/sdk/base/sdputils.h
@@ -15,6 +15,8 @@ class SdpUtils {
                                          std::vector<AudioCodec>& codec);
   static std::string SetPreferVideoCodecs(const std::string& sdp,
                                          std::vector<VideoCodec>& codec);
+  static std::string SetStartVideoBandwidth(const std::string& sdp,
+                                            int bandwidth);
  private:
   /**
    @brief Replace SDP for preferred codec.

--- a/talk/owt/sdk/base/sysinfo.cc
+++ b/talk/owt/sdk/base/sysinfo.cc
@@ -8,9 +8,9 @@
 #include "talk/owt/sdk/base/sysinfo.h"
 namespace owt {
 namespace base {
-static const std::string kSdkVersion("4.3");
+static const std::string kSdkVersion("4.2");
 static const std::string kRuntimeName("WebRTC");
-static const std::string kRuntimeVersion("76");
+static const std::string kRuntimeVersion("83");
 static const std::string kUnknown("Unknown");
 std::string SysInfo::SdkType() {
 #if defined(WEBRTC_IOS) || defined(WEBRTC_MAC)

--- a/talk/owt/sdk/base/webrtcvideorendererimpl.cc
+++ b/talk/owt/sdk/base/webrtcvideorendererimpl.cc
@@ -9,9 +9,11 @@
 #include <d3d9.h>
 #include <dxva2api.h>
 #endif
+#include "talk/owt/sdk/base/nativehandlebuffer.h"
 #include "talk/owt/sdk/base/webrtcvideorendererimpl.h"
 #if defined(WEBRTC_WIN)
 #include "talk/owt/sdk/base/win/d3dnativeframe.h"
+#include "talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h"
 #endif
 #include "webrtc/common_video/libyuv/include/webrtc_libyuv.h"
 
@@ -20,7 +22,50 @@ namespace base {
 void WebrtcVideoRendererImpl::OnFrame(const webrtc::VideoFrame& frame) {
   if (frame.video_frame_buffer()->type() ==
           webrtc::VideoFrameBuffer::Type::kNative) {
+#if defined(WEBRTC_WIN)
+    // This is D3D11Handle passed. Pass that directly to the attached renderer.
+    D3D11VAHandle* native_handle = reinterpret_cast<D3D11VAHandle*>(
+        reinterpret_cast<owt::base::NativeHandleBuffer*>(
+            frame.video_frame_buffer().get())
+            ->native_handle());
+
+    if (native_handle == nullptr)
+      return;
+
+    ID3D11Device* render_device = native_handle->d3d11_device;
+    ID3D11VideoDevice* render_video_device = native_handle->d3d11_video_device;
+    ID3D11Texture2D* texture = native_handle->texture;
+    ID3D11VideoContext* render_context = native_handle->context;
+    int index = native_handle->array_index;
+
+    uint16_t width = frame.video_frame_buffer()->width();
+    uint16_t height = frame.video_frame_buffer()->height();
+
+    if (width == 0 || height == 0)
+      return;
+
+    if (render_device == nullptr || render_video_device == nullptr || texture == nullptr)
+      return;
+
+    D3D11VAHandle* render_ptr = new D3D11VAHandle();
+    render_ptr->texture = texture;
+    render_ptr->array_index = index;
+    render_ptr->d3d11_device = render_device;
+    render_ptr->d3d11_video_device = render_video_device;
+    render_ptr->context = render_context;
+    render_ptr->side_data_size = native_handle->side_data_size;
+    if (native_handle->side_data_size > 0)
+      memcpy(&render_ptr->side_data[0], &native_handle->side_data[0],
+             native_handle->side_data_size);
+
+    Resolution resoluton(frame.width(), frame.height());
+    std::unique_ptr<VideoBuffer> video_buffer(
+        new VideoBuffer{render_ptr, resoluton, VideoBufferType::kD3D11Handle});
+
+    renderer_.RenderFrame(std::move(video_buffer));
+#else
     return;
+#endif
   }
   VideoRendererType renderer_type = renderer_.Type();
   if (renderer_type != VideoRendererType::kI420 &&

--- a/talk/owt/sdk/base/webrtcvideorendererimpl.h
+++ b/talk/owt/sdk/base/webrtcvideorendererimpl.h
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_WEBRTCVIDEORENDERERIMPL_H_
 #define OWT_BASE_WEBRTCVIDEORENDERERIMPL_H_
-
+#include "webrtc/api/media_stream_interface.h"
 #include "webrtc/api/video/video_sink_interface.h"
 #include "webrtc/api/video/video_frame.h"
 #include "talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h"

--- a/talk/owt/sdk/base/win/base_allocator.h
+++ b/talk/owt/sdk/base/win/base_allocator.h
@@ -2,241 +2,253 @@
 Copyright (c) 2005-2018, Intel Corporation
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This sample was distributed or derived from the Intel's Media Samples package.
-The original version of this sample may be obtained from https://software.intel.com/en-us/intel-media-server-studio
-or https://software.intel.com/en-us/media-client-solutions-support.
+The original version of this sample may be obtained from
+https://software.intel.com/en-us/intel-media-server-studio or
+https://software.intel.com/en-us/media-client-solutions-support.
 \**********************************************************************************/
 
 // Copyright (C) <2018> Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef OWT_BASE_WIN_BASEALLOCATOR_H__
 #define OWT_BASE_WIN_BASEALLOCATOR_H__
 
-#include <list>
 #include <string.h>
 #include <functional>
+#include <list>
 #include "mfxvideo.h"
 #include <memory>
+#include <mutex>
 #include "msdkcommon.h"
 
 namespace owt {
 namespace base {
 
-struct mfxAllocatorParams
-{
-    virtual ~mfxAllocatorParams(){}
+struct mfxAllocatorParams {
+  virtual ~mfxAllocatorParams() {}
 };
 
 // this class implements methods declared in mfxFrameAllocator structure
-// simply redirecting them to virtual methods which should be overridden in derived classes
-class MFXFrameAllocator : public mfxFrameAllocator
-{
-public:
-    MFXFrameAllocator();
-    virtual ~MFXFrameAllocator();
+// simply redirecting them to virtual methods which should be overridden in
+// derived classes
+class MFXFrameAllocator : public mfxFrameAllocator {
+ public:
+  MFXFrameAllocator();
+  virtual ~MFXFrameAllocator();
 
-     // optional method, override if need to pass some parameters to allocator from application
-    virtual mfxStatus Init(mfxAllocatorParams *pParams) = 0;
-    virtual mfxStatus Close() = 0;
+  // optional method, override if need to pass some parameters to allocator from
+  // application
+  virtual mfxStatus Init(mfxAllocatorParams* pParams) = 0;
+  virtual mfxStatus Close() = 0;
 
-    virtual mfxStatus AllocFrames(mfxFrameAllocRequest *request, mfxFrameAllocResponse *response) = 0;
-    virtual mfxStatus LockFrame(mfxMemId mid, mfxFrameData *ptr) = 0;
-    virtual mfxStatus UnlockFrame(mfxMemId mid, mfxFrameData *ptr) = 0;
-    virtual mfxStatus GetFrameHDL(mfxMemId mid, mfxHDL *handle) = 0;
-    virtual mfxStatus FreeFrames(mfxFrameAllocResponse *response) = 0;
+  virtual mfxStatus AllocFrames(mfxFrameAllocRequest* request,
+                                mfxFrameAllocResponse* response) = 0;
+  virtual mfxStatus LockFrame(mfxMemId mid, mfxFrameData* ptr) = 0;
+  virtual mfxStatus UnlockFrame(mfxMemId mid, mfxFrameData* ptr) = 0;
+  virtual mfxStatus GetFrameHDL(mfxMemId mid, mfxHDL* handle) = 0;
+  virtual mfxStatus FreeFrames(mfxFrameAllocResponse* response) = 0;
 
-private:
-    static mfxStatus MFX_CDECL  Alloc_(mfxHDL pthis, mfxFrameAllocRequest *request, mfxFrameAllocResponse *response);
-    static mfxStatus MFX_CDECL  Lock_(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr);
-    static mfxStatus MFX_CDECL  Unlock_(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr);
-    static mfxStatus MFX_CDECL  GetHDL_(mfxHDL pthis, mfxMemId mid, mfxHDL *handle);
-    static mfxStatus MFX_CDECL  Free_(mfxHDL pthis, mfxFrameAllocResponse *response);
+ private:
+  static mfxStatus MFX_CDECL Alloc_(mfxHDL pthis,
+                                    mfxFrameAllocRequest* request,
+                                    mfxFrameAllocResponse* response);
+  static mfxStatus MFX_CDECL Lock_(mfxHDL pthis,
+                                   mfxMemId mid,
+                                   mfxFrameData* ptr);
+  static mfxStatus MFX_CDECL Unlock_(mfxHDL pthis,
+                                     mfxMemId mid,
+                                     mfxFrameData* ptr);
+  static mfxStatus MFX_CDECL GetHDL_(mfxHDL pthis,
+                                     mfxMemId mid,
+                                     mfxHDL* handle);
+  static mfxStatus MFX_CDECL Free_(mfxHDL pthis,
+                                   mfxFrameAllocResponse* response);
 };
 
 // This class implements basic logic of memory allocator
-// Manages responses for different components according to allocation request type
-// External frames of a particular component-related type are allocated in one call
-// Further calls return previously allocated response.
-// Ex. Preallocated frame chain with type=FROM_ENCODE | FROM_VPPIN will be returned when
-// request type contains either FROM_ENCODE or FROM_VPPIN
+// Manages responses for different components according to allocation request
+// type External frames of a particular component-related type are allocated in
+// one call Further calls return previously allocated response. Ex. Preallocated
+// frame chain with type=FROM_ENCODE | FROM_VPPIN will be returned when request
+// type contains either FROM_ENCODE or FROM_VPPIN
 
 // This class does not allocate any actual memory
 
-class BaseFrameAllocator: public MFXFrameAllocator
-{
-public:
-    BaseFrameAllocator();
-    virtual ~BaseFrameAllocator();
+class BaseFrameAllocator : public MFXFrameAllocator {
+ public:
+  BaseFrameAllocator();
+  virtual ~BaseFrameAllocator();
 
-    virtual mfxStatus Init(mfxAllocatorParams *pParams) = 0;
-    virtual mfxStatus Close();
-    virtual mfxStatus AllocFrames(mfxFrameAllocRequest *request, mfxFrameAllocResponse *response);
-    virtual mfxStatus FreeFrames(mfxFrameAllocResponse *response);
+  virtual mfxStatus Init(mfxAllocatorParams* pParams) = 0;
+  virtual mfxStatus Close();
+  virtual mfxStatus AllocFrames(mfxFrameAllocRequest* request,
+                                mfxFrameAllocResponse* response);
+  virtual mfxStatus FreeFrames(mfxFrameAllocResponse* response);
 
-protected:
-    std::mutex mtx;
-    typedef std::list<mfxFrameAllocResponse>::iterator Iter;
-    static const mfxU32 MEMTYPE_FROM_MASK = MFX_MEMTYPE_FROM_ENCODE | MFX_MEMTYPE_FROM_DECODE | \
-                                            MFX_MEMTYPE_FROM_VPPIN | MFX_MEMTYPE_FROM_VPPOUT | \
-                                            MFX_MEMTYPE_FROM_ENC | MFX_MEMTYPE_FROM_PAK;
+ protected:
+  mutable std::mutex mtx;
+  typedef std::list<mfxFrameAllocResponse>::iterator Iter;
+  static const mfxU32 MEMTYPE_FROM_MASK =
+      MFX_MEMTYPE_FROM_ENCODE | MFX_MEMTYPE_FROM_DECODE |
+      MFX_MEMTYPE_FROM_VPPIN | MFX_MEMTYPE_FROM_VPPOUT | MFX_MEMTYPE_FROM_ENC |
+      MFX_MEMTYPE_FROM_PAK;
 
-    static const mfxU32 MEMTYPE_FROM_MASK_INT_EXT = MEMTYPE_FROM_MASK | MFX_MEMTYPE_INTERNAL_FRAME | MFX_MEMTYPE_EXTERNAL_FRAME;
+  static const mfxU32 MEMTYPE_FROM_MASK_INT_EXT = MEMTYPE_FROM_MASK |
+                                                  MFX_MEMTYPE_INTERNAL_FRAME |
+                                                  MFX_MEMTYPE_EXTERNAL_FRAME;
 
-    struct UniqueResponse
-        : mfxFrameAllocResponse
-    {
-        mfxU16 m_width;
-        mfxU16 m_height;
-        mfxU32 m_refCount;
-        mfxU16 m_type;
+  struct UniqueResponse : mfxFrameAllocResponse {
+    mfxU16 m_width;
+    mfxU16 m_height;
+    mfxU32 m_refCount;
+    mfxU16 m_type;
 
-        UniqueResponse()
-            : m_width(0)
-            , m_height(0)
-            , m_refCount(0)
-            , m_type(0)
-        {
-            memset(static_cast<mfxFrameAllocResponse*>(this), 0, sizeof(mfxFrameAllocResponse));
+    UniqueResponse() : m_width(0), m_height(0), m_refCount(0), m_type(0) {
+      memset(static_cast<mfxFrameAllocResponse*>(this), 0,
+             sizeof(mfxFrameAllocResponse));
+    }
+
+    // compare responses by actual frame size, alignment (w and h) is up to
+    // application
+    UniqueResponse(const mfxFrameAllocResponse& response,
+                   mfxU16 width,
+                   mfxU16 height,
+                   mfxU16 type)
+        : mfxFrameAllocResponse(response),
+          m_width(width),
+          m_height(height),
+          m_refCount(1),
+          m_type(type) {}
+
+    // compare by resolution (and memory type for FEI ENC / PAK)
+    bool operator()(const UniqueResponse& response) const {
+      if (m_width <= response.m_width && m_height <= response.m_height) {
+        // For FEI ENC and PAK we need to distinguish between INTERNAL and
+        // EXTERNAL frames
+
+        if (m_type & response.m_type &
+            (MFX_MEMTYPE_FROM_ENC | MFX_MEMTYPE_FROM_PAK)) {
+          return !!((m_type & response.m_type) & 0x000f);
+        } else {
+          return !!(m_type & response.m_type & MFX_MEMTYPE_FROM_DECODE);
         }
+      } else {
+        return false;
+      }
+    }
 
-        // compare responses by actual frame size, alignment (w and h) is up to application
-        UniqueResponse(const mfxFrameAllocResponse & response, mfxU16 width, mfxU16 height, mfxU16 type)
-            : mfxFrameAllocResponse(response)
-            , m_width(width)
-            , m_height(height)
-            , m_refCount(1)
-            , m_type(type)
-        {
-        }
+    static mfxU16 CropMemoryTypeToStore(mfxU16 type) {
+      // Remain INTERNAL / EXTERNAL flag for FEI ENC / PAK
+      switch (type & 0xf000) {
+        case MFX_MEMTYPE_FROM_ENC:
+        case MFX_MEMTYPE_FROM_PAK:
+        case (MFX_MEMTYPE_FROM_ENC | MFX_MEMTYPE_FROM_PAK):
+          return type & MEMTYPE_FROM_MASK_INT_EXT;
+          break;
+        default:
+          return type & MEMTYPE_FROM_MASK;
+          break;
+      }
+    }
+  };
 
-        //compare by resolution (and memory type for FEI ENC / PAK)
-        bool operator () (const UniqueResponse &response)const
-        {
-            if (m_width <= response.m_width && m_height <= response.m_height)
-            {
-                // For FEI ENC and PAK we need to distinguish between INTERNAL and EXTERNAL frames
+  std::list<mfxFrameAllocResponse> m_responses;
+  std::list<UniqueResponse> m_ExtResponses;
 
-                if (m_type & response.m_type & (MFX_MEMTYPE_FROM_ENC | MFX_MEMTYPE_FROM_PAK))
-                {
-                    return !!((m_type & response.m_type) & 0x000f);
-                }
-                else
-                {
-                    return !!(m_type & response.m_type & MFX_MEMTYPE_FROM_DECODE);
-                }
-            }
-            else
-            {
-                return false;
-            }
-        }
+  struct IsSame : public std::binary_function<mfxFrameAllocResponse,
+                                              mfxFrameAllocResponse,
+                                              bool> {
+    bool operator()(const mfxFrameAllocResponse& l,
+                    const mfxFrameAllocResponse& r) const {
+      return r.mids != 0 && l.mids != 0 && r.mids[0] == l.mids[0] &&
+             r.NumFrameActual == l.NumFrameActual;
+    }
+  };
 
-        static mfxU16 CropMemoryTypeToStore(mfxU16 type)
-        {
-            // Remain INTERNAL / EXTERNAL flag for FEI ENC / PAK
-            switch (type & 0xf000)
-            {
-            case MFX_MEMTYPE_FROM_ENC:
-            case MFX_MEMTYPE_FROM_PAK:
-            case (MFX_MEMTYPE_FROM_ENC | MFX_MEMTYPE_FROM_PAK):
-                return type & MEMTYPE_FROM_MASK_INT_EXT;
-                break;
-            default:
-                return type & MEMTYPE_FROM_MASK;
-                break;
-            }
-        }
-    };
+  // checks if request is supported
+  virtual mfxStatus CheckRequestType(mfxFrameAllocRequest* request);
 
-    std::list<mfxFrameAllocResponse> m_responses;
-    std::list<UniqueResponse> m_ExtResponses;
+  // frees memory attached to response
+  virtual mfxStatus ReleaseResponse(mfxFrameAllocResponse* response) = 0;
+  // allocates memory
+  virtual mfxStatus AllocImpl(mfxFrameAllocRequest* request,
+                              mfxFrameAllocResponse* response) = 0;
 
-    struct IsSame
-        : public std::binary_function<mfxFrameAllocResponse, mfxFrameAllocResponse, bool>
-    {
-        bool operator () (const mfxFrameAllocResponse & l, const mfxFrameAllocResponse &r)const
-        {
-            return r.mids != 0 && l.mids != 0 &&
-                r.mids[0] == l.mids[0] &&
-                r.NumFrameActual == l.NumFrameActual;
-        }
-    };
+  template <class T>
+  class safe_array {
+   public:
+    safe_array(T* ptr = 0) : m_ptr(ptr) {  // construct from object pointer
+    }
+    ~safe_array() { reset(0); }
+    T* get() {  // return wrapped pointer
+      return m_ptr;
+    }
+    T* release() {  // return wrapped pointer and give up ownership
+      T* ptr = m_ptr;
+      m_ptr = 0;
+      return ptr;
+    }
+    void reset(T* ptr) {  // destroy designated object and store new pointer
+      if (m_ptr) {
+        delete[] m_ptr;
+      }
+      m_ptr = ptr;
+    }
 
-    // checks if request is supported
-    virtual mfxStatus CheckRequestType(mfxFrameAllocRequest *request);
-
-    // frees memory attached to response
-    virtual mfxStatus ReleaseResponse(mfxFrameAllocResponse *response) = 0;
-    // allocates memory
-    virtual mfxStatus AllocImpl(mfxFrameAllocRequest *request, mfxFrameAllocResponse *response) = 0;
-
-    template <class T>
-    class safe_array
-    {
-    public:
-        safe_array(T *ptr = 0):m_ptr(ptr)
-        { // construct from object pointer
-        }
-        ~safe_array()
-        {
-            reset(0);
-        }
-        T* get()
-        { // return wrapped pointer
-            return m_ptr;
-        }
-        T* release()
-        { // return wrapped pointer and give up ownership
-            T* ptr = m_ptr;
-            m_ptr = 0;
-            return ptr;
-        }
-        void reset(T* ptr)
-        { // destroy designated object and store new pointer
-            if (m_ptr)
-            {
-                delete[] m_ptr;
-            }
-            m_ptr = ptr;
-        }
-    protected:
-        T* m_ptr; // the wrapped object pointer
-    private:
-        safe_array(const safe_array& );
-        safe_array& operator=(const safe_array& );
-    };
+   protected:
+    T* m_ptr;  // the wrapped object pointer
+   private:
+    safe_array(const safe_array&);
+    safe_array& operator=(const safe_array&);
+  };
 };
 
-class MFXBufferAllocator : public mfxBufferAllocator
-{
-public:
-    MFXBufferAllocator();
-    virtual ~MFXBufferAllocator();
+class MFXBufferAllocator : public mfxBufferAllocator {
+ public:
+  MFXBufferAllocator();
+  virtual ~MFXBufferAllocator();
 
-    virtual mfxStatus AllocBuffer(mfxU32 nbytes, mfxU16 type, mfxMemId *mid) = 0;
-    virtual mfxStatus LockBuffer(mfxMemId mid, mfxU8 **ptr) = 0;
-    virtual mfxStatus UnlockBuffer(mfxMemId mid) = 0;
-    virtual mfxStatus FreeBuffer(mfxMemId mid) = 0;
+  virtual mfxStatus AllocBuffer(mfxU32 nbytes, mfxU16 type, mfxMemId* mid) = 0;
+  virtual mfxStatus LockBuffer(mfxMemId mid, mfxU8** ptr) = 0;
+  virtual mfxStatus UnlockBuffer(mfxMemId mid) = 0;
+  virtual mfxStatus FreeBuffer(mfxMemId mid) = 0;
 
-private:
-    static mfxStatus MFX_CDECL  Alloc_(mfxHDL pthis, mfxU32 nbytes, mfxU16 type, mfxMemId *mid);
-    static mfxStatus MFX_CDECL  Lock_(mfxHDL pthis, mfxMemId mid, mfxU8 **ptr);
-    static mfxStatus MFX_CDECL  Unlock_(mfxHDL pthis, mfxMemId mid);
-    static mfxStatus MFX_CDECL  Free_(mfxHDL pthis, mfxMemId mid);
+ private:
+  static mfxStatus MFX_CDECL Alloc_(mfxHDL pthis,
+                                    mfxU32 nbytes,
+                                    mfxU16 type,
+                                    mfxMemId* mid);
+  static mfxStatus MFX_CDECL Lock_(mfxHDL pthis, mfxMemId mid, mfxU8** ptr);
+  static mfxStatus MFX_CDECL Unlock_(mfxHDL pthis, mfxMemId mid);
+  static mfxStatus MFX_CDECL Free_(mfxHDL pthis, mfxMemId mid);
 };
-}
-}
-#endif // OWT_BASE_WIN_BASEALLOCATOR_H__
+}  // namespace base
+}  // namespace owt
+#endif  // OWT_BASE_WIN_BASEALLOCATOR_H__

--- a/talk/owt/sdk/base/win/d3d11_allocator.cc
+++ b/talk/owt/sdk/base/win/d3d11_allocator.cc
@@ -17,510 +17,446 @@ The original version of this sample may be obtained from https://software.intel.
 or https://software.intel.com/en-us/media-client-solutions-support.
 \**********************************************************************************/
 
-// Copyright (C) <2018> Intel Corporation
+// Copyright (C) <2020> Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
+// This file is borrowed from MediaSDK sample with modification.
 #if defined(WEBRTC_WIN)
 
 #include "msdkvideobase.h"
 
+#pragma warning(disable : 4068)  // Unknown pragma
+#pragma warning(disable : 4996)  // Declared deprecated
+#pragma warning(disable : 4163)  // 'identifier' : not available as an intrinsic function
+
+#include "d3d11_allocator.h"
 #include <objbase.h>
 #include <initguid.h>
 #include <assert.h>
 #include <algorithm>
 #include <functional>
 #include <iterator>
-#include "d3d11_allocator.h"
 
 #define D3DFMT_NV12 (DXGI_FORMAT)MAKEFOURCC('N','V','1','2')
 #define D3DFMT_YV12 (DXGI_FORMAT)MAKEFOURCC('Y','V','1','2')
 
 namespace owt {
 namespace base {
-//for generating sequence of mfx handles
+// For generating sequence of mfx handles
 template <typename T>
 struct sequence {
     T x;
-    sequence(T seed) : x(seed) { }
+    sequence(T seed) : x(seed) {}
 };
 
 template <>
 struct sequence<mfxHDL> {
-    mfxHDL x;
-    sequence(mfxHDL seed) : x(seed) { }
+  mfxHDL x;
+  sequence(mfxHDL seed) : x(seed) {}
 
-    mfxHDL operator ()()
-    {
-        mfxHDL y = x;
-        x = (mfxHDL)(1 + (size_t)(x));
-        return y;
-    }
+  mfxHDL operator ()() {
+    mfxHDL y = x;
+    x = (mfxHDL)(1 + (size_t)(x));
+    return y;
+  }
 };
 
-
-D3D11FrameAllocator::D3D11FrameAllocator()
-{
-    m_pDeviceContext = NULL;
+D3D11FrameAllocator::D3D11FrameAllocator() {
+  m_pDeviceContext = nullptr;
 }
 
-D3D11FrameAllocator::~D3D11FrameAllocator()
-{
-    Close();
+D3D11FrameAllocator::~D3D11FrameAllocator() {
+  Close();
 }
 
-D3D11FrameAllocator::TextureSubResource  D3D11FrameAllocator::GetResourceFromMid(mfxMemId mid)
-{
-    size_t index = (size_t)MFXReadWriteMid(mid).raw() - 1;
+D3D11FrameAllocator::TextureSubResource  D3D11FrameAllocator::GetResourceFromMid(mfxMemId mid) {
+  size_t index = (size_t)MFXReadWriteMid(mid).raw() - 1;
 
-    if(m_memIdMap.size() <= index)
-        return TextureSubResource();
+  if(m_memIdMap.size() <= index)
+    return TextureSubResource();
 
-    //reverse iterator dereferencing
-    TextureResource * p = &(*m_memIdMap[index]);
-    if (!p->bAlloc)
-        return TextureSubResource();
+  // Reverse iterator dereferencing
+  TextureResource * p = &(*m_memIdMap[index]);
+  if (!p->bAlloc)
+    return TextureSubResource();
 
-    return TextureSubResource(p, mid);
+  return TextureSubResource(p, mid);
 }
 
-mfxStatus D3D11FrameAllocator::Init(mfxAllocatorParams *pParams)
-{
-    D3D11AllocatorParams *pd3d11Params = 0;
-    pd3d11Params = dynamic_cast<D3D11AllocatorParams *>(pParams);
+mfxStatus D3D11FrameAllocator::Init(mfxAllocatorParams *pParams) {
+  D3D11AllocatorParams *pd3d11Params = 0;
+  pd3d11Params = reinterpret_cast<D3D11AllocatorParams*>(pParams);
 
-    if (NULL == pd3d11Params ||
-        NULL == pd3d11Params->pDevice)
-    {
-        return MFX_ERR_NOT_INITIALIZED;
+  if (nullptr == pd3d11Params ||
+      nullptr == pd3d11Params->pDevice) {
+    return MFX_ERR_NOT_INITIALIZED;
+  }
+
+  m_initParams = *pd3d11Params;
+  MSDK_SAFE_RELEASE(m_pDeviceContext);
+  pd3d11Params->pDevice->GetImmediateContext(&m_pDeviceContext);
+
+  return MFX_ERR_NONE;
+}
+
+mfxStatus D3D11FrameAllocator::Close() {
+  mfxStatus sts = BaseFrameAllocator::Close();
+  for(referenceType i = m_resourcesByRequest.begin();
+    i != m_resourcesByRequest.end(); i++) {
+    i->Release();
+  }
+  m_resourcesByRequest.clear();
+  m_memIdMap.clear();
+  MSDK_SAFE_RELEASE(m_pDeviceContext);
+  return sts;
+}
+
+mfxStatus D3D11FrameAllocator::LockFrame(mfxMemId mid, mfxFrameData *ptr) {
+  HRESULT hRes = S_OK;
+
+  D3D11_TEXTURE2D_DESC desc = {0};
+  D3D11_MAPPED_SUBRESOURCE lockedRect = {0};
+
+  // Check that texture exists
+  TextureSubResource sr = GetResourceFromMid(mid);
+  if (!sr.GetTexture())
+    return MFX_ERR_LOCK_MEMORY;
+
+  D3D11_MAP mapType = D3D11_MAP_READ;
+  UINT mapFlags = D3D11_MAP_FLAG_DO_NOT_WAIT;
+  {
+    if (nullptr == sr.GetStaging()) {
+      hRes = m_pDeviceContext->Map(sr.GetTexture(), sr.GetSubResource(),
+          D3D11_MAP_READ, D3D11_MAP_FLAG_DO_NOT_WAIT, &lockedRect);
+      desc.Format = DXGI_FORMAT_P8;
+    } else {
+      sr.GetTexture()->GetDesc(&desc);
+
+      if (DXGI_FORMAT_NV12 != desc.Format &&
+          DXGI_FORMAT_420_OPAQUE != desc.Format &&
+          DXGI_FORMAT_YUY2 != desc.Format &&
+          DXGI_FORMAT_P8 != desc.Format &&
+          DXGI_FORMAT_B8G8R8A8_UNORM != desc.Format &&
+          DXGI_FORMAT_R16_UINT != desc.Format &&
+          DXGI_FORMAT_R16_UNORM != desc.Format &&
+          DXGI_FORMAT_R10G10B10A2_UNORM != desc.Format &&
+          DXGI_FORMAT_R16G16B16A16_UNORM != desc.Format &&
+          DXGI_FORMAT_P010 != desc.Format &&
+          DXGI_FORMAT_AYUV != desc.Format) {
+        return MFX_ERR_LOCK_MEMORY;
+      }
+
+      // Coping data only in case user wants to read from stored surface
+      {
+        if (MFXReadWriteMid(mid, MFXReadWriteMid::reuse).isRead()) {
+          m_pDeviceContext->CopySubresourceRegion(sr.GetStaging(),
+              0, 0, 0, 0, sr.GetTexture(), sr.GetSubResource(), NULL);
+        }
+
+        do {
+          hRes = m_pDeviceContext->Map(sr.GetStaging(), 0,
+              mapType, mapFlags, &lockedRect);
+          if (S_OK != hRes && DXGI_ERROR_WAS_STILL_DRAWING != hRes) {
+            msdk_printf(MSDK_STRING("ERROR: m_pDeviceContext->Map = 0x%08lx\n"), hRes);
+          }
+        } while (DXGI_ERROR_WAS_STILL_DRAWING == hRes);
+      }
     }
+  }
 
-    m_initParams = *pd3d11Params;
-    MSDK_SAFE_RELEASE(m_pDeviceContext);
-    pd3d11Params->pDevice->GetImmediateContext(&m_pDeviceContext);
+  if (FAILED(hRes))
+    return MFX_ERR_LOCK_MEMORY;
 
-    return MFX_ERR_NONE;
+  switch (desc.Format) {
+    case DXGI_FORMAT_P010:
+    case DXGI_FORMAT_NV12:
+      ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+      ptr->Y = (mfxU8 *)lockedRect.pData;
+      ptr->U = (mfxU8 *)lockedRect.pData + desc.Height * lockedRect.RowPitch;
+      ptr->V = (desc.Format == DXGI_FORMAT_P010) ? ptr->U + 2 : ptr->U + 1;
+      break;
+    case DXGI_FORMAT_420_OPAQUE: // can be unsupported by standard ms guid
+      ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+      ptr->Y = (mfxU8 *)lockedRect.pData;
+      ptr->V = ptr->Y + desc.Height * lockedRect.RowPitch;
+      ptr->U = ptr->V + (desc.Height * lockedRect.RowPitch) / 4;
+      break;
+    case DXGI_FORMAT_YUY2:
+      ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+      ptr->Y = (mfxU8 *)lockedRect.pData;
+      ptr->U = ptr->Y + 1;
+      ptr->V = ptr->Y + 3;
+      break;
+    case DXGI_FORMAT_P8 :
+      ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+      ptr->Y = (mfxU8 *)lockedRect.pData;
+      ptr->U = 0;
+      ptr->V = 0;
+      break;
+    case DXGI_FORMAT_AYUV:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+      ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+      ptr->B = (mfxU8 *)lockedRect.pData;
+      ptr->G = ptr->B + 1;
+      ptr->R = ptr->B + 2;
+      ptr->A = ptr->B + 3;
+      break;
+    case DXGI_FORMAT_R10G10B10A2_UNORM :
+      ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+      ptr->B = (mfxU8 *)lockedRect.pData;
+      ptr->G = ptr->B + 1;
+      ptr->R = ptr->B + 2;
+      ptr->A = ptr->B + 3;
+      break;
+    case DXGI_FORMAT_R16G16B16A16_UNORM:
+      ptr->V16 = (mfxU16*)lockedRect.pData;
+      ptr->U16 = ptr->V16 + 1;
+      ptr->Y16 = ptr->V16 + 2;
+      ptr->A = (mfxU8*)(ptr->V16 + 3);
+      ptr->PitchHigh = (mfxU16)((mfxU32)lockedRect.RowPitch / (1 << 16));
+      ptr->PitchLow  = (mfxU16)((mfxU32)lockedRect.RowPitch % (1 << 16));
+      break;
+    case DXGI_FORMAT_R16_UNORM :
+    case DXGI_FORMAT_R16_UINT :
+      ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+      ptr->Y16 = (mfxU16 *)lockedRect.pData;
+      ptr->U16 = 0;
+      ptr->V16 = 0;
+      break;
+    default:
+      return MFX_ERR_LOCK_MEMORY;
+  }
+  return MFX_ERR_NONE;
 }
 
-mfxStatus D3D11FrameAllocator::Close()
-{
-    mfxStatus sts = BaseFrameAllocator::Close();
-    for(referenceType i = m_resourcesByRequest.begin(); i != m_resourcesByRequest.end(); i++)
-    {
-        i->Release();
+mfxStatus D3D11FrameAllocator::UnlockFrame(mfxMemId mid, mfxFrameData *ptr) {
+  // Check that texture exists
+  TextureSubResource sr = GetResourceFromMid(mid);
+  if (!sr.GetTexture())
+    return MFX_ERR_LOCK_MEMORY;
+
+  if (nullptr == sr.GetStaging()) {
+    m_pDeviceContext->Unmap(sr.GetTexture(), sr.GetSubResource());
+  } else {
+    m_pDeviceContext->Unmap(sr.GetStaging(), 0);
+    // Only if user wrote something to texture
+    if (MFXReadWriteMid(mid, MFXReadWriteMid::reuse).isWrite()) {
+      m_pDeviceContext->CopySubresourceRegion(sr.GetTexture(),
+          sr.GetSubResource(), 0, 0, 0, sr.GetStaging(), 0, nullptr);
     }
-    m_resourcesByRequest.clear();
-    m_memIdMap.clear();
-    MSDK_SAFE_RELEASE(m_pDeviceContext);
+  }
+
+  if (ptr) {
+    ptr->Pitch=0;
+    ptr->U=ptr->V=ptr->Y=0;
+    ptr->A=ptr->R=ptr->G=ptr->B=0;
+  }
+
+  return MFX_ERR_NONE;
+}
+
+mfxStatus D3D11FrameAllocator::GetFrameHDL(mfxMemId mid, mfxHDL *handle) {
+  if (nullptr == handle)
+    return MFX_ERR_INVALID_HANDLE;
+
+  TextureSubResource sr = GetResourceFromMid(mid);
+
+  if (!sr.GetTexture())
+    return MFX_ERR_INVALID_HANDLE;
+
+  mfxHDLPair *pPair  =  (mfxHDLPair*)handle;
+  pPair->first  = sr.GetTexture();
+  pPair->second = (mfxHDL)(UINT_PTR)sr.GetSubResource();
+  return MFX_ERR_NONE;
+}
+
+mfxStatus D3D11FrameAllocator::CheckRequestType(mfxFrameAllocRequest *request) {
+  mfxStatus sts = BaseFrameAllocator::CheckRequestType(request);
+  if (MFX_ERR_NONE != sts)
     return sts;
-}
 
-mfxStatus D3D11FrameAllocator::LockFrame(mfxMemId mid, mfxFrameData *ptr)
-{
-    HRESULT hRes = S_OK;
-
-    D3D11_TEXTURE2D_DESC desc = {0};
-    D3D11_MAPPED_SUBRESOURCE lockedRect = {0};
-
-
-    //check that texture exists
-    TextureSubResource sr = GetResourceFromMid(mid);
-    if (!sr.GetTexture())
-        return MFX_ERR_LOCK_MEMORY;
-
-    D3D11_MAP mapType = D3D11_MAP_READ;
-    UINT mapFlags = D3D11_MAP_FLAG_DO_NOT_WAIT;
-    {
-        if (NULL == sr.GetStaging())
-        {
-            hRes = m_pDeviceContext->Map(sr.GetTexture(), sr.GetSubResource(), D3D11_MAP_READ, D3D11_MAP_FLAG_DO_NOT_WAIT, &lockedRect);
-            desc.Format = DXGI_FORMAT_P8;
-        }
-        else
-        {
-            sr.GetTexture()->GetDesc(&desc);
-
-            if (DXGI_FORMAT_NV12 != desc.Format &&
-                DXGI_FORMAT_420_OPAQUE != desc.Format &&
-                DXGI_FORMAT_YUY2 != desc.Format &&
-                DXGI_FORMAT_P8 != desc.Format &&
-                DXGI_FORMAT_B8G8R8A8_UNORM != desc.Format &&
-                DXGI_FORMAT_R16_UINT != desc.Format &&
-                DXGI_FORMAT_R16_UNORM != desc.Format &&
-                DXGI_FORMAT_R10G10B10A2_UNORM != desc.Format &&
-                DXGI_FORMAT_R16G16B16A16_UNORM != desc.Format &&
-                DXGI_FORMAT_P010 != desc.Format &&
-                DXGI_FORMAT_AYUV != desc.Format
-)
-            {
-                return MFX_ERR_LOCK_MEMORY;
-            }
-
-            //coping data only in case user wants to read from stored surface
-            {
-
-                if (MFXReadWriteMid(mid, MFXReadWriteMid::reuse).isRead())
-                {
-                    m_pDeviceContext->CopySubresourceRegion(sr.GetStaging(), 0, 0, 0, 0, sr.GetTexture(), sr.GetSubResource(), NULL);
-                }
-
-                do
-                {
-                    hRes = m_pDeviceContext->Map(sr.GetStaging(), 0, mapType, mapFlags, &lockedRect);
-                    if (S_OK != hRes && DXGI_ERROR_WAS_STILL_DRAWING != hRes)
-                    {
-                        msdk_printf(MSDK_STRING("ERROR: m_pDeviceContext->Map = 0x%08lx\n"), hRes);
-                    }
-                }
-                while (DXGI_ERROR_WAS_STILL_DRAWING == hRes);
-            }
-
-        }
-    }
-
-    if (FAILED(hRes))
-        return MFX_ERR_LOCK_MEMORY;
-
-    switch (desc.Format)
-    {
-        case DXGI_FORMAT_P010:
-        case DXGI_FORMAT_NV12:
-            ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-            ptr->Y = (mfxU8 *)lockedRect.pData;
-            ptr->U = (mfxU8 *)lockedRect.pData + desc.Height * lockedRect.RowPitch;
-            ptr->V = (desc.Format == DXGI_FORMAT_P010) ? ptr->U + 2 : ptr->U + 1;
-            break;
-
-        case DXGI_FORMAT_420_OPAQUE: // can be unsupported by standard ms guid
-            ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-            ptr->Y = (mfxU8 *)lockedRect.pData;
-            ptr->V = ptr->Y + desc.Height * lockedRect.RowPitch;
-            ptr->U = ptr->V + (desc.Height * lockedRect.RowPitch) / 4;
-
-            break;
-
-        case DXGI_FORMAT_YUY2:
-            ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-            ptr->Y = (mfxU8 *)lockedRect.pData;
-            ptr->U = ptr->Y + 1;
-            ptr->V = ptr->Y + 3;
-
-            break;
-
-        case DXGI_FORMAT_P8 :
-            ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-            ptr->Y = (mfxU8 *)lockedRect.pData;
-            ptr->U = 0;
-            ptr->V = 0;
-
-            break;
-
-        case DXGI_FORMAT_AYUV:
-        case DXGI_FORMAT_B8G8R8A8_UNORM:
-            ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-            ptr->B = (mfxU8 *)lockedRect.pData;
-            ptr->G = ptr->B + 1;
-            ptr->R = ptr->B + 2;
-            ptr->A = ptr->B + 3;
-
-            break;
-        case DXGI_FORMAT_R10G10B10A2_UNORM :
-            ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-            ptr->B = (mfxU8 *)lockedRect.pData;
-            ptr->G = ptr->B + 1;
-            ptr->R = ptr->B + 2;
-            ptr->A = ptr->B + 3;
-
-            break;
-        case DXGI_FORMAT_R16G16B16A16_UNORM:
-            ptr->V16 = (mfxU16*)lockedRect.pData;
-            ptr->U16 = ptr->V16 + 1;
-            ptr->Y16 = ptr->V16 + 2;
-            ptr->A = (mfxU8*)(ptr->V16 + 3);
-            ptr->PitchHigh = (mfxU16)((mfxU32)lockedRect.RowPitch / (1 << 16));
-            ptr->PitchLow  = (mfxU16)((mfxU32)lockedRect.RowPitch % (1 << 16));
-            break;
-        case DXGI_FORMAT_R16_UNORM :
-        case DXGI_FORMAT_R16_UINT :
-            ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-            ptr->Y16 = (mfxU16 *)lockedRect.pData;
-            ptr->U16 = 0;
-            ptr->V16 = 0;
-
-            break;
-        default:
-
-            return MFX_ERR_LOCK_MEMORY;
-    }
-
+  if ((request->Type & (MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET | MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET)) != 0)
     return MFX_ERR_NONE;
+  else
+    return MFX_ERR_UNSUPPORTED;
 }
 
-mfxStatus D3D11FrameAllocator::UnlockFrame(mfxMemId mid, mfxFrameData *ptr)
-{
-    //check that texture exists
-    TextureSubResource sr = GetResourceFromMid(mid);
-    if (!sr.GetTexture())
-        return MFX_ERR_LOCK_MEMORY;
+mfxStatus D3D11FrameAllocator::ReleaseResponse(mfxFrameAllocResponse *response) {
+  if (nullptr == response)
+    return MFX_ERR_NULL_PTR;
 
-    if (NULL == sr.GetStaging())
-    {
-        m_pDeviceContext->Unmap(sr.GetTexture(), sr.GetSubResource());
-    }
-    else
-    {
-        m_pDeviceContext->Unmap(sr.GetStaging(), 0);
-        //only if user wrote something to texture
-        if (MFXReadWriteMid(mid, MFXReadWriteMid::reuse).isWrite())
-        {
-            m_pDeviceContext->CopySubresourceRegion(sr.GetTexture(), sr.GetSubResource(), 0, 0, 0, sr.GetStaging(), 0, NULL);
-        }
-    }
-
-    if (ptr)
-    {
-        ptr->Pitch=0;
-        ptr->U=ptr->V=ptr->Y=0;
-        ptr->A=ptr->R=ptr->G=ptr->B=0;
-    }
-
-    return MFX_ERR_NONE;
-}
-
-
-mfxStatus D3D11FrameAllocator::GetFrameHDL(mfxMemId mid, mfxHDL *handle)
-{
-    if (NULL == handle)
-        return MFX_ERR_INVALID_HANDLE;
-
-    TextureSubResource sr = GetResourceFromMid(mid);
+  if (response->mids && 0 != response->NumFrameActual) {
+    // Check whether texture exsist
+    TextureSubResource sr = GetResourceFromMid(response->mids[0]);
 
     if (!sr.GetTexture())
-        return MFX_ERR_INVALID_HANDLE;
-
-    mfxHDLPair *pPair  =  (mfxHDLPair*)handle;
-
-    pPair->first  = sr.GetTexture();
-    pPair->second = (mfxHDL)(UINT_PTR)sr.GetSubResource();
-
-    return MFX_ERR_NONE;
-}
-
-mfxStatus D3D11FrameAllocator::CheckRequestType(mfxFrameAllocRequest *request)
-{
-    mfxStatus sts = BaseFrameAllocator::CheckRequestType(request);
-    if (MFX_ERR_NONE != sts)
-        return sts;
-
-    if ((request->Type & (MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET | MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET)) != 0)
-        return MFX_ERR_NONE;
-    else
-        return MFX_ERR_UNSUPPORTED;
-}
-
-mfxStatus D3D11FrameAllocator::ReleaseResponse(mfxFrameAllocResponse *response)
-{
-    if (NULL == response)
         return MFX_ERR_NULL_PTR;
 
-    if (response->mids && 0 != response->NumFrameActual)
-    {
-        //check whether texture exsist
-        TextureSubResource sr = GetResourceFromMid(response->mids[0]);
+    sr.Release();
 
-        if (!sr.GetTexture())
-            return MFX_ERR_NULL_PTR;
-
-        sr.Release();
-
-        //if texture is last it is possible to remove also all handles from map to reduce fragmentation
-        //search for allocated chunk
-        if (m_resourcesByRequest.end() == std::find_if(m_resourcesByRequest.begin(), m_resourcesByRequest.end(), TextureResource::isAllocated))
-        {
-            m_resourcesByRequest.clear();
-            m_memIdMap.clear();
-        }
+    // If texture is last it is possible to remove also all
+    // handles from map to reduce fragmentation search for allocated chunk
+    if (m_resourcesByRequest.end() == ::std::find_if(m_resourcesByRequest.begin(),
+        m_resourcesByRequest.end(), TextureResource::isAllocated)) {
+      m_resourcesByRequest.clear();
+      m_memIdMap.clear();
     }
+  }
 
-    return MFX_ERR_NONE;
+  return MFX_ERR_NONE;
 }
-mfxStatus D3D11FrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mfxFrameAllocResponse *response)
-{
-    HRESULT hRes;
 
-    DXGI_FORMAT colorFormat = ConverColortFormat(request->Info.FourCC);
+mfxStatus D3D11FrameAllocator::AllocImpl(mfxFrameAllocRequest *request,
+    mfxFrameAllocResponse *response) {
+  HRESULT hRes;
+  DXGI_FORMAT colorFormat = ConverColortFormat(request->Info.FourCC);
 
-    if (DXGI_FORMAT_UNKNOWN == colorFormat)
-    {
-       msdk_printf(MSDK_STRING("D3D11 Allocator: invalid fourcc is provided (%#X), exitting\n"),request->Info.FourCC);
-       return MFX_ERR_UNSUPPORTED;
-    }
+  if (DXGI_FORMAT_UNKNOWN == colorFormat) {
+     msdk_printf(MSDK_STRING("D3D11 Allocator: invalid fourcc is provided (%#X), exitting\n"),
+        request->Info.FourCC);
+    return MFX_ERR_UNSUPPORTED;
+  }
 
-    TextureResource newTexture;
+  TextureResource newTexture;
+  if (request->Info.FourCC == MFX_FOURCC_P8) {
+      D3D11_BUFFER_DESC desc = { 0 };
 
-    if (request->Info.FourCC == MFX_FOURCC_P8)
-    {
-        D3D11_BUFFER_DESC desc = { 0 };
+    desc.ByteWidth           = request->Info.Width * request->Info.Height;
+    desc.Usage               = D3D11_USAGE_STAGING;
+    desc.BindFlags           = 0;
+    desc.CPUAccessFlags      = D3D11_CPU_ACCESS_READ;
+    desc.MiscFlags           = 0;
+    desc.StructureByteStride = 0;
 
-        desc.ByteWidth           = request->Info.Width * request->Info.Height;
-        desc.Usage               = D3D11_USAGE_STAGING;
-        desc.BindFlags           = 0;
-        desc.CPUAccessFlags      = D3D11_CPU_ACCESS_READ;
-        desc.MiscFlags           = 0;
-        desc.StructureByteStride = 0;
+    ID3D11Buffer * buffer = 0;
+    hRes = m_initParams.pDevice->CreateBuffer(&desc, 0, &buffer);
+    if (FAILED(hRes))
+      return MFX_ERR_MEMORY_ALLOC;
 
-        ID3D11Buffer * buffer = 0;
-        hRes = m_initParams.pDevice->CreateBuffer(&desc, 0, &buffer);
-        if (FAILED(hRes))
-            return MFX_ERR_MEMORY_ALLOC;
+    newTexture.textures.push_back(reinterpret_cast<ID3D11Texture2D *>(buffer));
+  } else {
+    D3D11_TEXTURE2D_DESC desc = {0};
+    desc.Width = request->Info.Width;
+    desc.Height =  request->Info.Height;
 
-        newTexture.textures.push_back(reinterpret_cast<ID3D11Texture2D *>(buffer));
-    }
-    else
-    {
-        D3D11_TEXTURE2D_DESC desc = {0};
-
-        desc.Width = request->Info.Width;
-        desc.Height =  request->Info.Height;
-
-        desc.MipLevels = 1;
-        //number of subresources is 1 in case of not single texture
-        desc.ArraySize = m_initParams.bUseSingleTexture ? request->NumFrameSuggested : 1;
-        desc.Format = ConverColortFormat(request->Info.FourCC);
-        desc.SampleDesc.Count = 1;
-        desc.Usage = D3D11_USAGE_DEFAULT;
-        desc.MiscFlags = m_initParams.uncompressedResourceMiscFlags | D3D11_RESOURCE_MISC_SHARED;
+    desc.MipLevels = 1;
+    // Number of subresources is 1 in case of not single texture
+    desc.ArraySize = m_initParams.bUseSingleTexture ? request->NumFrameSuggested : 1;
+    desc.Format = ConverColortFormat(request->Info.FourCC);
+    desc.SampleDesc.Count = 1;
+    desc.Usage = D3D11_USAGE_DEFAULT;
+    desc.MiscFlags = m_initParams.uncompressedResourceMiscFlags | D3D11_RESOURCE_MISC_SHARED;
 #if (MFX_VERSION >= 1025)
-        if ((request->Type&MFX_MEMTYPE_VIDEO_MEMORY_ENCODER_TARGET) && (request->Type & MFX_MEMTYPE_INTERNAL_FRAME))
-        {
-            desc.BindFlags = D3D11_BIND_DECODER | D3D11_BIND_VIDEO_ENCODER;
-        }
-        else
+    if ((request->Type&MFX_MEMTYPE_VIDEO_MEMORY_ENCODER_TARGET)
+        && (request->Type & MFX_MEMTYPE_INTERNAL_FRAME)) {
+      desc.BindFlags = D3D11_BIND_DECODER | D3D11_BIND_VIDEO_ENCODER;
+    } else
 #endif
-            desc.BindFlags = D3D11_BIND_DECODER;
+    desc.BindFlags = D3D11_BIND_DECODER;
 
-        if ( (MFX_MEMTYPE_FROM_VPPIN & request->Type) && (DXGI_FORMAT_YUY2 == desc.Format) ||
-             (DXGI_FORMAT_B8G8R8A8_UNORM == desc.Format) ||
-             (DXGI_FORMAT_R10G10B10A2_UNORM == desc.Format) ||
-             (DXGI_FORMAT_R16G16B16A16_UNORM == desc.Format) )
-        {
-            desc.BindFlags = D3D11_BIND_RENDER_TARGET;
-            if (desc.ArraySize > 2)
-                return MFX_ERR_MEMORY_ALLOC;
-        }
-
-        if ( (MFX_MEMTYPE_FROM_VPPOUT & request->Type) ||
-             (MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET & request->Type))
-        {
-            desc.BindFlags = D3D11_BIND_RENDER_TARGET;
-            if (desc.ArraySize > 2)
-                return MFX_ERR_MEMORY_ALLOC;
-        }
-
-        if(request->Type&MFX_MEMTYPE_SHARED_RESOURCE)
-        {
-            desc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
-            desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
-        }
-
-        if( DXGI_FORMAT_P8 == desc.Format )
-        {
-            desc.BindFlags = 0;
-        }
-
-        ID3D11Texture2D* pTexture2D;
-
-        for(size_t i = 0; i < request->NumFrameSuggested / desc.ArraySize; i++)
-        {
-            hRes = m_initParams.pDevice->CreateTexture2D(&desc, NULL, &pTexture2D);
-
-            if (FAILED(hRes))
-            {
-                msdk_printf(MSDK_STRING("CreateTexture2D(%lld) failed, hr = 0x%08lx\n"), (long long)i, hRes);
-                return MFX_ERR_MEMORY_ALLOC;
-            }
-            newTexture.textures.push_back(pTexture2D);
-        }
-
-        desc.ArraySize = 1;
-        desc.Usage = D3D11_USAGE_STAGING;
-        desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-        desc.BindFlags = 0;
-        desc.MiscFlags = 0;
-
-        for(size_t i = 0; i < request->NumFrameSuggested; i++)
-        {
-            hRes = m_initParams.pDevice->CreateTexture2D(&desc, NULL, &pTexture2D);
-
-            if (FAILED(hRes))
-            {
-                msdk_printf(MSDK_STRING("Create staging texture(%lld) failed hr = 0x%X\n"), (long long)i, (unsigned int)hRes);
-                return MFX_ERR_MEMORY_ALLOC;
-            }
-            newTexture.stagingTexture.push_back(pTexture2D);
-        }
+    if ( (MFX_MEMTYPE_FROM_VPPIN & request->Type) && (DXGI_FORMAT_YUY2 == desc.Format) ||
+         (DXGI_FORMAT_B8G8R8A8_UNORM == desc.Format) ||
+         (DXGI_FORMAT_R10G10B10A2_UNORM == desc.Format) ||
+         (DXGI_FORMAT_R16G16B16A16_UNORM == desc.Format) ) {
+      desc.BindFlags = D3D11_BIND_RENDER_TARGET;
+      if (desc.ArraySize > 2)
+        return MFX_ERR_MEMORY_ALLOC;
     }
 
-    // mapping to self created handles array, starting from zero or from last assigned handle + 1
-    sequence<mfxHDL> seq_initializer(m_resourcesByRequest.empty() ? 0 :  m_resourcesByRequest.back().outerMids.back());
+    if ( (MFX_MEMTYPE_FROM_VPPOUT & request->Type) ||
+         (MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET & request->Type)) {
+      desc.BindFlags = D3D11_BIND_RENDER_TARGET;
+      if (desc.ArraySize > 2)
+        return MFX_ERR_MEMORY_ALLOC;
+    }
 
-    //incrementing starting index
-    //1. 0(NULL) is invalid memid
-    //2. back is last index not new one
-    seq_initializer();
+    if(request->Type&MFX_MEMTYPE_SHARED_RESOURCE) {
+      desc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
+      desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+    }
 
-    std::generate_n(std::back_inserter(newTexture.outerMids), request->NumFrameSuggested, seq_initializer);
+    if( DXGI_FORMAT_P8 == desc.Format ) {
+      desc.BindFlags = 0;
+    }
 
-    //saving texture resources
-    m_resourcesByRequest.push_back(newTexture);
+    ID3D11Texture2D* pTexture2D;
 
-    //providing pointer to mids externally
-    response->mids = &m_resourcesByRequest.back().outerMids.front();
-    response->NumFrameActual = request->NumFrameSuggested;
+    for(size_t i = 0; i < request->NumFrameSuggested / desc.ArraySize; i++) {
+      hRes = m_initParams.pDevice->CreateTexture2D(&desc, nullptr, &pTexture2D);
 
-    //iterator prior end()
-    std::list <TextureResource>::iterator it_last = m_resourcesByRequest.end();
-    //fill map
-    std::fill_n(std::back_inserter(m_memIdMap), request->NumFrameSuggested, --it_last);
+      if (FAILED(hRes)) {
+        msdk_printf(MSDK_STRING("CreateTexture2D(%lld) failed, hr = 0x%08lx\n"), (long long)i, hRes);
+        return MFX_ERR_MEMORY_ALLOC;
+      }
+      newTexture.textures.push_back(pTexture2D);
+    }
 
-    return MFX_ERR_NONE;
+    desc.ArraySize = 1;
+    desc.Usage = D3D11_USAGE_STAGING;
+    desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+    desc.BindFlags = 0;
+    desc.MiscFlags = 0;
+
+    for(size_t i = 0; i < request->NumFrameSuggested; i++) {
+      hRes = m_initParams.pDevice->CreateTexture2D(&desc, nullptr, &pTexture2D);
+
+      if (FAILED(hRes)) {
+        msdk_printf(MSDK_STRING("Create staging texture(%lld) failed hr = 0x%X\n"),
+          (long long)i, (unsigned int)hRes);
+        return MFX_ERR_MEMORY_ALLOC;
+      }
+      newTexture.stagingTexture.push_back(pTexture2D);
+    }
+  }
+
+  // Mapping to self created handles array,
+  // starting from zero or from last assigned handle + 1
+  sequence<mfxHDL> seq_initializer(m_resourcesByRequest.empty() ?
+      0 :  m_resourcesByRequest.back().outerMids.back());
+
+  seq_initializer();
+
+  std::generate_n(::std::back_inserter(newTexture.outerMids),
+      request->NumFrameSuggested, seq_initializer);
+
+  // Saving texture resources
+  m_resourcesByRequest.push_back(newTexture);
+
+  // Providing pointer to mids externally
+  response->mids = &m_resourcesByRequest.back().outerMids.front();
+  response->NumFrameActual = request->NumFrameSuggested;
+
+  std::list <TextureResource>::iterator it_last = m_resourcesByRequest.end();
+  std::fill_n(::std::back_inserter(m_memIdMap), request->NumFrameSuggested, --it_last);
+
+  return MFX_ERR_NONE;
 }
 
-DXGI_FORMAT D3D11FrameAllocator::ConverColortFormat(mfxU32 fourcc)
-{
-    switch (fourcc)
-    {
-        case MFX_FOURCC_NV12:
-            return DXGI_FORMAT_NV12;
-
-        case MFX_FOURCC_YUY2:
-            return DXGI_FORMAT_YUY2;
-
-        case MFX_FOURCC_RGB4:
-            return DXGI_FORMAT_B8G8R8A8_UNORM;
-
-        case MFX_FOURCC_P8:
-        case MFX_FOURCC_P8_TEXTURE:
-            return DXGI_FORMAT_P8;
-
-        case MFX_FOURCC_ARGB16:
-        case MFX_FOURCC_ABGR16:
-            return DXGI_FORMAT_R16G16B16A16_UNORM;
-
-        case MFX_FOURCC_P010:
-            return DXGI_FORMAT_P010;
-
-        case MFX_FOURCC_A2RGB10:
-            return DXGI_FORMAT_R10G10B10A2_UNORM;
-
-        case DXGI_FORMAT_AYUV:
-        case MFX_FOURCC_AYUV:
-            return DXGI_FORMAT_AYUV;
-
-        default:
-            return DXGI_FORMAT_UNKNOWN;
-    }
+DXGI_FORMAT D3D11FrameAllocator::ConverColortFormat(mfxU32 fourcc) {
+  switch (fourcc) {
+    case MFX_FOURCC_NV12:
+      return DXGI_FORMAT_NV12;
+    case MFX_FOURCC_YUY2:
+      return DXGI_FORMAT_YUY2;
+    case MFX_FOURCC_RGB4:
+      return DXGI_FORMAT_B8G8R8A8_UNORM;
+    case MFX_FOURCC_P8:
+    case MFX_FOURCC_P8_TEXTURE:
+      return DXGI_FORMAT_P8;
+    case MFX_FOURCC_ARGB16:
+    case MFX_FOURCC_ABGR16:
+      return DXGI_FORMAT_R16G16B16A16_UNORM;
+    case MFX_FOURCC_P010:
+      return DXGI_FORMAT_P010;
+    case MFX_FOURCC_A2RGB10:
+      return DXGI_FORMAT_R10G10B10A2_UNORM;
+    case DXGI_FORMAT_AYUV:
+    case MFX_FOURCC_AYUV:
+      return DXGI_FORMAT_AYUV;
+    default:
+      return DXGI_FORMAT_UNKNOWN;
+  }
 }
 }  // namespace base
 }  // namespace owt

--- a/talk/owt/sdk/base/win/d3d11_allocator.h
+++ b/talk/owt/sdk/base/win/d3d11_allocator.h
@@ -36,250 +36,197 @@ https://software.intel.com/en-us/intel-media-server-studio
 or https://software.intel.com/en-us/media-client-solutions-support.
 \**********************************************************************************/
 
-// Copyright (C) <2018> Intel Corporation
+// Copyright (C) <2020> Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// This file is borrowed from MSDK sample with some minor modification.
-#ifndef OWT_BASE_WIN_D3D11ALLOCATOR_H__
-#define OWT_BASE_WIN_D3D11ALLOCATOR_H__
+// This file is borrowed from MSDK sample with modification.
+#ifndef OWT_BASE_WIN_D3D11ALLOCATOR_H_
+#define OWT_BASE_WIN_D3D11ALLOCATOR_H_
 
 #include "base_allocator.h"
 #include <limits>
-
-namespace owt {
-namespace base {
-// Application can provide either generic mid from surface or this wrapper
-// wrapper distinguishes from generic mid by highest 1 bit
-// if it set then remained pointer points to extended structure of memid
-// 64 bits system layout
-/*----+-----------------------------------------------------------+
-|b63=1|63 bits remained for pointer to extended structure of memid|
-|b63=0|63 bits from original mfxMemId                             |
-+-----+----------------------------------------------------------*/
-//32 bits system layout
-/*--+---+--------------------------------------------+
-|b31=1|31 bits remained for pointer to extended memid|
-|b31=0|31 bits remained for surface pointer          |
-+---+---+-------------------------------------------*/
-//#pragma warning (disable:4293)
-class MFXReadWriteMid
-{
-    static const uintptr_t bits_offset = std::numeric_limits<uintptr_t>::digits - 1;
-    static const uintptr_t clear_mask = ~((uintptr_t)1 << bits_offset);
-public:
-    enum
-    {
-        // If flag not set it means that read and write
-        not_set = 0,
-        reuse   = 1,
-        read    = 2,
-        write   = 4,
-    };
-    // Here mfxmemid might be as MFXReadWriteMid or mfxMemId memid
-    MFXReadWriteMid(mfxMemId mid, mfxU8 flag = not_set)
-    {
-        //setup mid
-        m_mid_to_report = (mfxMemId)((uintptr_t)&m_mid | ((uintptr_t)1 << bits_offset));
-        if (0 != ((uintptr_t)mid >> bits_offset))
-        {
-            //it points to extended structure
-            mfxMedIdEx * pMemIdExt = reinterpret_cast<mfxMedIdEx *>((uintptr_t)mid & clear_mask);
-            m_mid.pId = pMemIdExt->pId;
-            if (reuse == flag)
-            {
-                m_mid.read_write = pMemIdExt->read_write;
-            }
-            else
-            {
-                m_mid.read_write = flag;
-            }
-        }
-        else
-        {
-            m_mid.pId = mid;
-            if (reuse == flag)
-                m_mid.read_write = not_set;
-            else
-                m_mid.read_write = flag;
-        }
-
-    }
-    bool isRead() const
-    {
-        return 0 != (m_mid.read_write & read) || !m_mid.read_write;
-    }
-    bool isWrite() const
-    {
-        return 0 != (m_mid.read_write & write) || !m_mid.read_write;
-    }
-    /// returns original memid without read write flags
-    mfxMemId raw() const
-    {
-        return m_mid.pId;
-    }
-    operator mfxMemId() const
-    {
-        return m_mid_to_report;
-    }
-
-private:
-    struct mfxMedIdEx
-    {
-        mfxMemId pId;
-        mfxU8 read_write;
-    };
-
-    mfxMedIdEx m_mid;
-    mfxMemId   m_mid_to_report;
-};
-
-#if defined(WEBRTC_WIN)
-
 #include <d3d11.h>
 #include <vector>
 #include <map>
+#include <list>
 
 struct ID3D11VideoDevice;
 struct ID3D11VideoContext;
 
-struct D3D11AllocatorParams : mfxAllocatorParams
-{
-    ID3D11Device *pDevice;
-    bool bUseSingleTexture;
-    DWORD uncompressedResourceMiscFlags;
+namespace owt {
+namespace base {
 
-    D3D11AllocatorParams()
-        : pDevice()
-        , bUseSingleTexture()
-        , uncompressedResourceMiscFlags()
-    {
-    }
+class MFXReadWriteMid {
+ public:
+  static const uintptr_t bits_offset = std::numeric_limits<uintptr_t>::digits - 1;
+  static const uintptr_t clear_mask = ~((uintptr_t)1 << bits_offset);
+ public:
+  enum {
+    // If flag not set it means that read and write
+    not_set = 0,
+    reuse   = 1,
+    read    = 2,
+    write   = 4,
+  };
+  // Here mfxmemid might be as MFXReadWriteMid or mfxMemId memid
+  MFXReadWriteMid(mfxMemId mid, mfxU8 flag = not_set) {
+      // Setup mid
+      m_mid_to_report = (mfxMemId)((uintptr_t)&m_mid | ((uintptr_t)1 << bits_offset));
+      if (0 != ((uintptr_t)mid >> bits_offset)) {
+          // Points to extended structure
+          mfxMedIdEx * pMemIdExt = reinterpret_cast<mfxMedIdEx *>((uintptr_t)mid & clear_mask);
+          m_mid.pId = pMemIdExt->pId;
+          if (reuse == flag) {
+              m_mid.read_write = pMemIdExt->read_write;
+          }
+          else {
+              m_mid.read_write = flag;
+          }
+      } else {
+          m_mid.pId = mid;
+          if (reuse == flag)
+              m_mid.read_write = not_set;
+          else
+              m_mid.read_write = flag;
+      }
+  }
+  bool isRead() const {
+      return 0 != (m_mid.read_write & read) || !m_mid.read_write;
+  }
+  bool isWrite() const {
+      return 0 != (m_mid.read_write & write) || !m_mid.read_write;
+  }
+  // Returns original memid without read write flags
+  mfxMemId raw() const {
+      return m_mid.pId;
+  }
+  operator mfxMemId() const {
+      return m_mid_to_report;
+  }
+
+private:
+  struct mfxMedIdEx {
+    mfxMemId pId;
+    mfxU8 read_write;
+  };
+
+  mfxMedIdEx m_mid;
+  mfxMemId   m_mid_to_report;
 };
 
-class D3D11FrameAllocator: public BaseFrameAllocator
-{
-public:
+struct D3D11AllocatorParams : mfxAllocatorParams {
+  ID3D11Device *pDevice;
+  bool bUseSingleTexture;
+  DWORD uncompressedResourceMiscFlags;
 
-    D3D11FrameAllocator();
-    virtual ~D3D11FrameAllocator();
+  D3D11AllocatorParams()
+      : pDevice()
+      , bUseSingleTexture()
+      , uncompressedResourceMiscFlags() {
+  }
+};
 
-    virtual mfxStatus Init(mfxAllocatorParams *pParams);
-    virtual mfxStatus Close();
-    virtual ID3D11Device * GetD3D11Device()
-    {
-        return m_initParams.pDevice;
-    };
-    virtual mfxStatus LockFrame(mfxMemId mid, mfxFrameData *ptr);
-    virtual mfxStatus UnlockFrame(mfxMemId mid, mfxFrameData *ptr);
-    virtual mfxStatus GetFrameHDL(mfxMemId mid, mfxHDL *handle);
+class D3D11FrameAllocator: public BaseFrameAllocator {
+ public:
+  D3D11FrameAllocator();
+  virtual ~D3D11FrameAllocator();
+  virtual mfxStatus Init(mfxAllocatorParams *pParams);
+  virtual mfxStatus Close();
+  virtual ID3D11Device * GetD3D11Device() {
+    return m_initParams.pDevice;
+  };
+  virtual mfxStatus LockFrame(mfxMemId mid, mfxFrameData *ptr);
+  virtual mfxStatus UnlockFrame(mfxMemId mid, mfxFrameData *ptr);
+  virtual mfxStatus GetFrameHDL(mfxMemId mid, mfxHDL *handle);
 
 protected:
-    static  DXGI_FORMAT ConverColortFormat(mfxU32 fourcc);
-    virtual mfxStatus CheckRequestType(mfxFrameAllocRequest *request);
-    virtual mfxStatus ReleaseResponse(mfxFrameAllocResponse *response);
-    virtual mfxStatus AllocImpl(mfxFrameAllocRequest *request, mfxFrameAllocResponse *response);
+  static  DXGI_FORMAT ConverColortFormat(mfxU32 fourcc);
+  virtual mfxStatus CheckRequestType(mfxFrameAllocRequest *request);
+  virtual mfxStatus ReleaseResponse(mfxFrameAllocResponse *response);
+  virtual mfxStatus AllocImpl(mfxFrameAllocRequest *request, mfxFrameAllocResponse *response);
 
-    D3D11AllocatorParams m_initParams;
-    ID3D11DeviceContext *m_pDeviceContext;
+  D3D11AllocatorParams m_initParams;
+  ID3D11DeviceContext *m_pDeviceContext;
 
-    struct TextureResource
-    {
-        std::vector<mfxMemId> outerMids;
-        std::vector<ID3D11Texture2D*> textures;
-        std::vector<ID3D11Texture2D*> stagingTexture;
-        bool             bAlloc;
+  struct TextureResource {
+    std::vector<mfxMemId> outerMids;
+    std::vector<ID3D11Texture2D*> textures;
+    std::vector<ID3D11Texture2D*> stagingTexture;
+    bool             bAlloc;
+    TextureResource()
+        : bAlloc(true) {
+    }
+    static bool isAllocated (TextureResource & that) {
+      return that.bAlloc;
+    }
+    ID3D11Texture2D* GetTexture(mfxMemId id) {
+      if (outerMids.empty())
+        return NULL;
+      return textures[((uintptr_t)id - (uintptr_t)outerMids.front()) % textures.size()];
+    }
+    UINT GetSubResource(mfxMemId id) {
+      if (outerMids.empty())
+        return NULL;
+      return (UINT)(((uintptr_t)id - (uintptr_t)outerMids.front()) / textures.size());
+    }
+    void Release() {
+      size_t i = 0;
+      for(i = 0; i < textures.size(); i++) {
+        textures[i]->Release();
+      }
+      textures.clear();
 
-        TextureResource()
-            : bAlloc(true)
-        {
-        }
+      for(i = 0; i < stagingTexture.size(); i++) {
+        stagingTexture[i]->Release();
+      }
+      stagingTexture.clear();
 
-        static bool isAllocated (TextureResource & that)
-        {
-            return that.bAlloc;
-        }
-        ID3D11Texture2D* GetTexture(mfxMemId id)
-        {
-            if (outerMids.empty())
-                return NULL;
+      // Marking texture as deallocated
+      bAlloc = false;
+    }
+  };
+  class TextureSubResource {
+   private:
+    TextureResource * m_pTarget;
+    ID3D11Texture2D * m_pTexture;
+    ID3D11Texture2D * m_pStaging;
+    UINT m_subResource;
+   public:
+    TextureSubResource(TextureResource * pTarget = NULL, mfxMemId id = 0)
+        : m_pTarget(pTarget)
+        , m_pTexture()
+        , m_subResource()
+        , m_pStaging(nullptr) {
+          if (nullptr!= m_pTarget && !m_pTarget->outerMids.empty()) {
+            ptrdiff_t idx = (uintptr_t)MFXReadWriteMid(id).raw() - (uintptr_t)m_pTarget->outerMids.front();
+            m_pTexture = m_pTarget->textures[idx % m_pTarget->textures.size()];
+            m_subResource = (UINT)(idx / m_pTarget->textures.size());
+            m_pStaging = m_pTarget->stagingTexture.empty() ? NULL : m_pTarget->stagingTexture[idx];
+          }
+    }
+    ID3D11Texture2D* GetStaging() const {
+      return m_pStaging;
+    }
+    ID3D11Texture2D* GetTexture() const {
+      return m_pTexture;
+    }
+    UINT GetSubResource() const {
+      return m_subResource;
+    }
+    void Release() {
+      if (nullptr != m_pTarget)
+        m_pTarget->Release();
+      }
+  };
 
-            return textures[((uintptr_t)id - (uintptr_t)outerMids.front()) % textures.size()];
-        }
-        UINT GetSubResource(mfxMemId id)
-        {
-            if (outerMids.empty())
-                return NULL;
+  TextureSubResource GetResourceFromMid(mfxMemId);
+  std::list<TextureResource> m_resourcesByRequest;//each alloc request generates new item in list
 
-            return (UINT)(((uintptr_t)id - (uintptr_t)outerMids.front()) / textures.size());
-        }
-        void Release()
-        {
-            size_t i = 0;
-            for(i = 0; i < textures.size(); i++)
-            {
-                textures[i]->Release();
-            }
-            textures.clear();
-
-            for(i = 0; i < stagingTexture.size(); i++)
-            {
-                stagingTexture[i]->Release();
-            }
-            stagingTexture.clear();
-
-            //marking texture as deallocated
-            bAlloc = false;
-        }
-    };
-    class TextureSubResource
-    {
-        TextureResource * m_pTarget;
-        ID3D11Texture2D * m_pTexture;
-        ID3D11Texture2D * m_pStaging;
-        UINT m_subResource;
-    public:
-        TextureSubResource(TextureResource * pTarget = NULL, mfxMemId id = 0)
-            : m_pTarget(pTarget)
-            , m_pTexture()
-            , m_subResource()
-            , m_pStaging(NULL)
-        {
-            if (NULL != m_pTarget && !m_pTarget->outerMids.empty())
-            {
-                ptrdiff_t idx = (uintptr_t)MFXReadWriteMid(id).raw() - (uintptr_t)m_pTarget->outerMids.front();
-                m_pTexture = m_pTarget->textures[idx % m_pTarget->textures.size()];
-                m_subResource = (UINT)(idx / m_pTarget->textures.size());
-                m_pStaging = m_pTarget->stagingTexture.empty() ? NULL : m_pTarget->stagingTexture[idx];
-            }
-        }
-        ID3D11Texture2D* GetStaging()const
-        {
-            return m_pStaging;
-        }
-        ID3D11Texture2D* GetTexture()const
-        {
-            return m_pTexture;
-        }
-        UINT GetSubResource()const
-        {
-            return m_subResource;
-        }
-        void Release()
-        {
-            if (NULL != m_pTarget)
-                m_pTarget->Release();
-        }
-    };
-
-    TextureSubResource GetResourceFromMid(mfxMemId);
-
-    std::list <TextureResource> m_resourcesByRequest;//each alloc request generates new item in list
-
-    typedef std::list <TextureResource>::iterator referenceType;
-    std::vector<referenceType> m_memIdMap;
+  typedef ::std::list<TextureResource>::iterator referenceType;
+  std::vector<referenceType> m_memIdMap;
 };
 }  // namespace base
 }  // namespace owt
-#endif // #if defined(WEBRTC_WIN)
-#endif // OWT_BASE_WIN_D3D11ALLOCATOR_H__
+
+#endif // OWT_BASE_WIN_D3D11ALLOCATOR_H_

--- a/talk/owt/sdk/base/win/d3d11device.cc
+++ b/talk/owt/sdk/base/win/d3d11device.cc
@@ -1,0 +1,130 @@
+// Copyright (C) <2020> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is borrowed from MSDK sample with modification
+
+#include "talk/owt/sdk/base/win/d3d11device.h"
+#include "rtc_base/logging.h"
+
+#define MSDK_D3D11_CHECK(result) \
+  {                        \
+    if (FAILED(result)) {  \
+      RTC_LOG(LS_ERROR) << "Failed with result:" << result; \
+      return MFX_ERR_DEVICE_FAILED;  \
+    }  \
+  }
+
+namespace owt {
+namespace base {
+
+RTCD3D11Device::RTCD3D11Device() {
+}
+
+RTCD3D11Device::~RTCD3D11Device() {
+  Close();
+}
+
+mfxStatus RTCD3D11Device::Init(mfxHDL window,
+  mfxU32 adapter_num, ID3D11Device* device) {
+  window_handle_ = static_cast<HWND>(window);
+  HRESULT hr;
+
+  if (device != nullptr) {
+    external_d3d11_device_ = device;
+
+    // First get the immediate device context;
+    device->GetImmediateContext(&external_d3d11_device_context_);
+    if (external_d3d11_device_context_ == nullptr)
+      return MFX_ERR_DEVICE_FAILED;
+
+    // Get the ID3D11VideoDevice handle as well.
+    hr = device->QueryInterface(__uuidof(ID3D11VideoDevice),
+                                (void**)&external_d3d11_video_device_);
+    if (FAILED(hr))
+      return MFX_ERR_DEVICE_FAILED;
+
+    hr = external_d3d11_device_context_->QueryInterface(__uuidof(ID3D11VideoContext),
+                                (void**)&external_d3d11_video_context_);
+    if (FAILED(hr))
+      return MFX_ERR_DEVICE_FAILED;
+
+    CComQIPtr<ID3D10Multithread> p_mt(external_d3d11_video_context_);
+    if (p_mt) {
+      p_mt->SetMultithreadProtected(true);
+    } else {
+      return MFX_ERR_DEVICE_FAILED;
+    }
+    return MFX_ERR_NONE;
+  }
+
+  RTC_LOG(LS_ERROR) << "In d3d11device: Before create the dxgi factory.";
+  static D3D_FEATURE_LEVEL feature_levels[] = {
+    D3D_FEATURE_LEVEL_11_1,
+    D3D_FEATURE_LEVEL_11_0,
+    D3D_FEATURE_LEVEL_10_1,
+    D3D_FEATURE_LEVEL_10_1
+  };
+
+  D3D_FEATURE_LEVEL feature_levels_out;
+  MSDK_D3D11_CHECK(CreateDXGIFactory(__uuidof(IDXGIFactory2),
+     (void**)(&dxgi_factory_)));
+  
+  RTC_LOG(LS_ERROR) << "In d3d11device: Before enumerating adapters.";
+  MSDK_D3D11_CHECK(dxgi_factory_->EnumAdapters(adapter_num, &dxgi_adapter_));
+
+  RTC_LOG(LS_ERROR) << "In d3d11device: Before D3D11CreateDevice.";
+  MSDK_D3D11_CHECK(D3D11CreateDevice(dxgi_adapter_, D3D_DRIVER_TYPE_UNKNOWN, nullptr, 0,
+                           feature_levels, MSDK_ARRAY_LEN(feature_levels),
+                           D3D11_SDK_VERSION, &d3d11_device_,
+                           &feature_levels_out, &d3d11_device_context_));
+
+  dxgi_device_ = d3d11_device_;
+  d3d11_video_device_ = d3d11_device_;
+  d3d11_video_context_ = d3d11_device_context_;
+
+  if (!dxgi_device_.p || !d3d11_video_device_.p || !d3d11_video_context_.p) {
+    RTC_LOG(LS_ERROR) << "d3d11 device or context nullptr";
+    return MFX_ERR_NULL_PTR;
+  }
+
+  // Turn on multi-threading for the context
+  CComQIPtr<ID3D10Multithread> p_mt(d3d11_video_context_);
+  if (p_mt) {
+    p_mt->SetMultithreadProtected(true);
+  } else {
+    RTC_LOG(LS_ERROR) << "Failed to turn on multi-threading for the context.";
+    return MFX_ERR_DEVICE_FAILED;
+  }
+
+  return MFX_ERR_NONE;
+}
+
+mfxStatus RTCD3D11Device::Reset() {
+  // Currently do nothing.
+  return MFX_ERR_NONE;
+}
+
+mfxStatus RTCD3D11Device::SetHandle(mfxHandleType handle_type, mfxHDL handle) {
+  if (handle != nullptr) {
+    window_handle_ = static_cast<HWND>(handle);
+    return MFX_ERR_NONE;
+  }
+  return MFX_ERR_UNSUPPORTED;
+}
+
+mfxStatus RTCD3D11Device::GetHandle(mfxHandleType handle_type, mfxHDL* handle) {
+  if (MFX_HANDLE_D3D11_DEVICE == handle_type) {
+    *handle = external_d3d11_device_ != nullptr ? external_d3d11_device_
+                                                : d3d11_device_.p;
+    return MFX_ERR_NONE;
+  }
+  return MFX_ERR_UNSUPPORTED;
+}
+
+void RTCD3D11Device::Close() {
+  window_handle_ = nullptr;
+}
+
+}
+}

--- a/talk/owt/sdk/base/win/d3d11device.h
+++ b/talk/owt/sdk/base/win/d3d11device.h
@@ -1,0 +1,69 @@
+// Copyright (C) <2020> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OWT_BASE_WIN_D3D11DEVICE_H_
+#define OWT_BASE_WIN_D3D11DEVICE_H_
+
+#include <atlbase.h>
+#include <d3d11.h>
+#include <dxgi1_2.h>
+#include <windows.h>
+
+#include "talk/owt/sdk/base/win/msdkvideobase.h"
+
+namespace owt {
+namespace base {
+
+class RTCD3D11Device {
+ public:
+  RTCD3D11Device();
+  virtual ~RTCD3D11Device();
+
+  mfxStatus Init(mfxHDL window, mfxU32 adapter_idx, ID3D11Device* device);
+  mfxStatus Reset();
+  mfxStatus SetHandle(mfxHandleType handle_type, mfxHDL handle);
+  mfxStatus GetHandle(mfxHandleType handle_type, mfxHDL* handle);
+  void Close();
+
+  ID3D11Device* GetD3D11Device() const {
+    if (external_d3d11_device_ != nullptr)
+      return external_d3d11_device_;
+    else
+      return d3d11_device_.p;
+  }
+
+  ID3D11VideoDevice* GetD3D11VideoDevice() const {
+    if (external_d3d11_video_device_ != nullptr)
+      return external_d3d11_video_device_;
+    else
+      return d3d11_video_device_.p;
+  }
+  ID3D11VideoContext* GetContext() const {
+    if (external_d3d11_video_context_ != nullptr)
+      return external_d3d11_video_context_;
+    else
+      return d3d11_video_context_.p;
+  }
+
+ private:
+  CComPtr<ID3D11Device> d3d11_device_;
+  CComPtr<ID3D11DeviceContext> d3d11_device_context_;
+  CComQIPtr<ID3D11VideoDevice> d3d11_video_device_;
+  CComQIPtr<ID3D11VideoContext> d3d11_video_context_;
+
+  CComQIPtr<IDXGIDevice1> dxgi_device_;
+  CComQIPtr<IDXGIAdapter> dxgi_adapter_;
+  CComPtr<IDXGIFactory2> dxgi_factory_;
+  CComPtr<IDXGISwapChain1> dxgi_swap_chain_;
+
+  HWND window_handle_ = nullptr;
+
+  // External device. Decoder does not need the context.
+  ID3D11Device* external_d3d11_device_ = nullptr;
+  ID3D11DeviceContext* external_d3d11_device_context_ = nullptr;
+  ID3D11VideoDevice* external_d3d11_video_device_ = nullptr;
+  ID3D11VideoContext* external_d3d11_video_context_ = nullptr;
+};
+}  // namespace base
+}  // namespace owt
+#endif

--- a/talk/owt/sdk/base/win/d3d11va_h264_decoder.cc
+++ b/talk/owt/sdk/base/win/d3d11va_h264_decoder.cc
@@ -1,0 +1,435 @@
+// Copyright (C) <20> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "talk/owt/sdk/base/nativehandlebuffer.h"
+#include "talk/owt/sdk/base/win/d3d11va_h264_decoder.h"
+#include <algorithm>
+#include <limits>
+
+#include "webrtc/api/video/color_space.h"
+#include "webrtc/api/video/i420_buffer.h"
+#include "webrtc/common_video/include/video_frame_buffer.h"
+#include "webrtc/modules/video_coding/codecs/h264/h264_color_space.h"
+#include "webrtc/rtc_base/checks.h"
+#include "webrtc/rtc_base/critical_section.h"
+#include "webrtc/rtc_base/keep_ref_until_done.h"
+#include "webrtc/rtc_base/logging.h"
+#include "system_wrappers/include/metrics.h"
+
+namespace owt {
+namespace base {
+
+namespace {
+
+const AVPixelFormat kPixelFormatDefault = AV_PIX_FMT_YUV420P;
+const AVPixelFormat kPixelFormatFullRange = AV_PIX_FMT_YUVJ420P;
+const size_t kYPlaneIndex = 0;
+const size_t kUPlaneIndex = 1;
+const size_t kVPlaneIndex = 2;
+static const int kMaxSideDataListSize = 20;
+
+// Used by histograms. Values of entries should not be changed.
+enum H264DecoderImplEvent {
+  kH264DecoderEventInit = 0,
+  kH264DecoderEventError = 1,
+  kH264DecoderEventMax = 16,
+};
+
+}  // namespace
+
+static const uint8_t frame_number_sei_guid[16] = {0xef, 0xc8, 0xe7, 0xb0, 0x26,
+    0x26, 0x47, 0xfd, 0x9d, 0xa3, 0x49, 0x4f, 0x60, 0xb8, 0x5b, 0xf0};
+static enum AVPixelFormat hw_pix_fmt;
+static enum AVPixelFormat get_hw_format(AVCodecContext* ctx,
+                                        const enum AVPixelFormat* pix_fmts) {
+  const enum AVPixelFormat* p;
+
+  for (p = pix_fmts; *p != -1; p++) {
+    if (*p == hw_pix_fmt)
+      return *p;
+  }
+
+  return AV_PIX_FMT_NONE;
+}
+
+H264DXVADecoderImpl::H264DXVADecoderImpl(ID3D11Device* external_device)
+    : decoded_image_callback_(nullptr),
+                                     has_reported_init_(false),
+                                     has_reported_error_(false) {
+  surface_handle_.reset(new D3D11VAHandle());
+}
+
+H264DXVADecoderImpl::~H264DXVADecoderImpl() {
+  Release();
+}
+
+int H264DXVADecoderImpl::InitHwContext(AVCodecContext* ctx,
+                                       const enum AVHWDeviceType type) {
+  int err = 0;
+  AVBufferRef* device_ref = NULL;
+  AVHWDeviceContext* device_ctx;
+  AVD3D11VADeviceContext* device_hwctx;
+
+  HRESULT hr;
+  UINT creation_flags = D3D11_CREATE_DEVICE_VIDEO_SUPPORT;
+  static D3D_FEATURE_LEVEL feature_levels[] = {
+      D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1,
+      D3D_FEATURE_LEVEL_10_1 };
+
+  D3D_FEATURE_LEVEL feature_levels_out;
+
+  device_ref = av_hwdevice_ctx_alloc(type);
+  if (!device_ref) {
+    RTC_LOG(LS_ERROR) << "Failed to allocate d3d11va hw context.";
+    err = -1;
+    goto fail;
+  }
+
+  device_ctx = (AVHWDeviceContext*)device_ref->data;
+  device_hwctx = (AVD3D11VADeviceContext*)device_ctx->hwctx;
+
+  hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr,
+      creation_flags, feature_levels, sizeof(feature_levels) / sizeof(feature_levels[0]), D3D11_SDK_VERSION,
+      &device_hwctx->device, &feature_levels_out, &d3d11_device_context_);
+  if (FAILED(hr)) {
+    err = -1;
+    goto fail;
+  }
+
+  d3d11_device_ = device_hwctx->device;
+
+  if (d3d11_device_) {
+    hr = d3d11_device_->QueryInterface(__uuidof(ID3D11VideoDevice),
+        (void**)&d3d11_video_device_);
+    if (FAILED(hr)) {
+      err = -1;
+      goto fail;
+    }
+  }
+  if (d3d11_device_context_) {
+    hr = d3d11_device_context_->QueryInterface(__uuidof(ID3D11VideoContext),
+        (void**)&d3d11_video_context_);
+    if (FAILED(hr)) {
+      err = -1;
+      goto fail;
+    }
+  }
+  // Turn on multi-threading for the context
+  {
+    CComQIPtr<ID3D10Multithread> p_mt(device_hwctx->device);
+    if (p_mt) {
+      p_mt->SetMultithreadProtected(true);
+    }
+  }
+
+  err = av_hwdevice_ctx_init(device_ref);
+  if (err < 0) {
+    RTC_LOG(LS_ERROR) << "Failed hwdevice_ctx_init.";
+    goto fail;
+  }
+
+  hw_device_ctx = device_ref;
+  ctx->hw_device_ctx = av_buffer_ref(hw_device_ctx);
+  return 0;
+
+fail:
+  av_buffer_unref(&device_ref);
+  hw_device_ctx = nullptr;
+  return err;
+}
+
+int H264DXVADecoderImpl::PrepareHwDecoder(webrtc::VideoCodecType codec_type) {
+  int ret = 0;
+  enum AVHWDeviceType type;
+
+  type = av_hwdevice_find_type_by_name("d3d11va");
+  if (type == AV_HWDEVICE_TYPE_NONE) {
+    RTC_LOG(LS_ERROR) << "D3D11VA HW decoder not found. Avaiable decoders: ";
+    while ((type = av_hwdevice_iterate_types(type)) != AV_HWDEVICE_TYPE_NONE) {
+      RTC_LOG(LS_ERROR) << av_hwdevice_get_type_name(type);
+      return -1;
+    }
+  }
+
+  AVCodecID codec_id = codec_type == webrtc::VideoCodecType::kVideoCodecH264
+                           ? AV_CODEC_ID_H264
+                           : AV_CODEC_ID_HEVC;
+
+  decoder = avcodec_find_decoder(codec_id);
+  if (!decoder) {
+    RTC_LOG(LS_ERROR) << "Decoder not found by avcodec_find_decoder.";
+    return -1;
+  }
+
+  for (int i = 0;; i++) {
+    const AVCodecHWConfig* config = avcodec_get_hw_config(decoder, i);
+    if (!config) {
+      RTC_LOG(LS_ERROR) << "Decoder " << decoder->name
+        << " does not support device type: "
+        << av_hwdevice_get_type_name(type);
+      return -1;
+    }
+    if (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX &&
+      config->device_type == type) {
+      hw_pix_fmt = config->pix_fmt;
+      break;
+    }
+  }
+
+  if (!(decoder_ctx = avcodec_alloc_context3(decoder))) {
+    RTC_LOG(LS_ERROR) << "Failed on alloc_context.";
+    return -1;
+  }
+
+  decoder_ctx->get_format = get_hw_format;
+
+  if (InitHwContext(decoder_ctx, type) < 0) {
+    RTC_LOG(LS_ERROR) << "Failed InitHwContext.";
+    return -1;
+  }
+
+  if ((ret = avcodec_open2(decoder_ctx, decoder, NULL)) < 0) {
+    RTC_LOG(LS_ERROR) << "Failed to open decoder.";
+    return -1;
+  }
+  return 0;
+}
+
+int32_t H264DXVADecoderImpl::InitDecode(const webrtc::VideoCodec* codec_settings,
+                                    int32_t number_of_cores) {
+  ReportInit();
+  if (codec_settings &&
+      (codec_settings->codecType != webrtc::kVideoCodecH264 
+#ifndef DISABLE_H265
+      && codec_settings->codecType != webrtc::kVideoCodecH265)
+#endif
+  ) {
+    RTC_LOG(LS_ERROR) << "in H264DXVADecoderImpl: codec mismatch.";
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  // Release necessary in case of re-initializing.
+  int32_t ret = Release();
+  if (ret != WEBRTC_VIDEO_CODEC_OK) {
+    ReportError();
+    return ret;
+  }
+
+  ret = PrepareHwDecoder(codec_settings->codecType);
+  if (ret < 0) {
+    RTC_LOG(LS_ERROR) << "Failed to prepare the hw decoder.";
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t H264DXVADecoderImpl::Release() {
+  // Do we need to flush the decoder? Currently we don't.
+  if (decoder_ctx != nullptr) {
+    avcodec_free_context(&decoder_ctx);
+    decoder_ctx = nullptr;
+  }
+  if (hw_device_ctx != nullptr) {
+    av_buffer_unref(&hw_device_ctx);
+    hw_device_ctx = nullptr;
+  }
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t H264DXVADecoderImpl::RegisterDecodeCompleteCallback(
+    webrtc::DecodedImageCallback* callback) {
+  decoded_image_callback_ = callback;
+  return WEBRTC_VIDEO_CODEC_OK;
+}
+
+int32_t H264DXVADecoderImpl::Decode(const webrtc::EncodedImage& input_image,
+                                bool /*missing_frames*/,
+                                int64_t /*render_time_ms*/) {
+  if (!IsInitialized()) {
+    ReportError();
+    RTC_LOG(LS_ERROR) << "Decoder not initialized.";
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+  if (!decoded_image_callback_) {
+    RTC_LOG(LS_WARNING)
+        << "InitDecode() has been called, but a callback function "
+           "has not been set with RegisterDecodeCompleteCallback()";
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
+  }
+  if (!input_image.data() || !input_image.size()) {
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
+  }
+
+  AVFrame* frame = nullptr;
+  AVPacket packet;
+  av_init_packet(&packet);
+  packet.data = input_image.mutable_data();
+
+  if (input_image.size() >
+      static_cast<size_t>(std::numeric_limits<int>::max())) {
+    ReportError();
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+  packet.size = static_cast<int>(input_image.size());
+
+  GetSideData(input_image.mutable_data(), input_image.size(), current_side_data_);
+  if (current_side_data_.size() > 0) {
+    side_data_list_[input_image.Timestamp()] = current_side_data_;
+  }
+  decoder_ctx->reordered_opaque = (int64_t)input_image.Timestamp();
+
+  int result = avcodec_send_packet(decoder_ctx, &packet);
+  if (result < 0) {
+    RTC_LOG(LS_ERROR) << "Send packet returned error: " << result;
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
+
+  // Consume buffer until we have a frame.
+  while (true) {
+    if (!(frame = av_frame_alloc())) {
+      RTC_LOG(LS_ERROR) << "Failed to alloc frame for decoding.";
+      goto fail;
+    }
+
+    result = avcodec_receive_frame(decoder_ctx, frame);
+    if (result == AVERROR(EAGAIN) || result == AVERROR_EOF) {
+      av_frame_free(&frame);
+      RTC_LOG(LS_VERBOSE) << "No frame. Return from decoder.";
+      return WEBRTC_VIDEO_CODEC_OK;
+    }
+    else if (result < 0) {
+      RTC_LOG(LS_ERROR) << "Error happend during decoding.";
+      goto fail;
+    }
+
+    // We get one frame from the decoder.
+    if (frame != nullptr && frame->format == hw_pix_fmt) {
+      ID3D11Texture2D* texture = (ID3D11Texture2D*)frame->data[0];
+      int index = (intptr_t)frame->data[1];
+      D3D11_TEXTURE2D_DESC texture_desc;
+
+      if (texture == nullptr) {
+        RTC_LOG(LS_ERROR) << "Invalid output texture.";
+        goto fail;
+      }
+      texture->GetDesc(&texture_desc);
+      if (decoded_image_callback_) {
+        if (!d3d11_device_ || !d3d11_video_device_ || !d3d11_video_context_) {
+          RTC_LOG(LS_ERROR)
+            << "Invalid d3d11 context to be passed to renderer.";
+          goto fail;
+        }
+
+        uint32_t pts = static_cast<uint32_t>(frame->reordered_opaque);
+        size_t side_data_size = 0;
+        RtlZeroMemory(&surface_handle_->side_data[0],
+                      OWT_ENCODED_IMAGE_SIDE_DATA_SIZE_MAX);
+        if (side_data_list_.find(pts) != side_data_list_.end()) {
+          side_data_size = side_data_list_[pts].size();
+          for (int i = 0; i < side_data_size; i++) {
+            surface_handle_->side_data[i] = side_data_list_[pts][i];
+          }
+          side_data_list_.erase(pts);
+          if (side_data_list_.size() > kMaxSideDataListSize) {
+            // If side_data_list_ grows too large, clear it.
+            side_data_list_.clear();
+          }
+        }
+        // Should we only send the d3d11device, and let renderer derive video
+        // device and context by itself?
+        surface_handle_->texture = texture;
+        surface_handle_->d3d11_device = d3d11_device_.p;
+        surface_handle_->d3d11_video_device = d3d11_video_device_.p;
+        surface_handle_->context = d3d11_video_context_.p;
+        surface_handle_->array_index = index;
+        surface_handle_->side_data_size = side_data_size;
+        rtc::scoped_refptr<owt::base::NativeHandleBuffer> buffer =
+          new rtc::RefCountedObject<owt::base::NativeHandleBuffer>(
+          (void*)surface_handle_.get(), texture_desc.Width,
+            texture_desc.Height);
+        webrtc::VideoFrame decoded_frame(buffer, input_image.Timestamp(), 0,
+          webrtc::kVideoRotation_0);
+        decoded_frame.set_ntp_time_ms(input_image.ntp_time_ms_);
+        decoded_frame.set_timestamp(input_image.Timestamp());
+        decoded_image_callback_->Decoded(decoded_frame);
+
+      }
+      av_frame_free(&frame);
+    }
+  }
+  return WEBRTC_VIDEO_CODEC_OK;
+
+fail:
+  av_frame_free(&frame);
+  return WEBRTC_VIDEO_CODEC_ERROR;
+}
+
+// Helper function to extract the prefix-SEI.
+int64_t H264DXVADecoderImpl::GetSideData(const uint8_t* frame_data,
+  size_t frame_size, std::vector<uint8_t>& side_data) {
+  side_data.clear();
+  if (frame_size < 24)  // with prefix-frame-num sei, frame size needs to be at least 24 bytes.
+    goto failed;
+
+  const uint8_t* head = frame_data;
+  unsigned int payload_size = 0;
+
+  if (head[0] != 0 || head[1] != 0 || head[2] != 0 || head[3] != 1) {
+    goto failed;
+  }
+  if ((head[4] & 0x1f) == 0x06) {
+    if (head[5] == 0x05) { // user data unregistered.
+      payload_size = head[6];
+      if (payload_size > frame_size - 4 - 4 || payload_size < 17) //. 4-byte start code + 4 byte NAL HDR/Payload Type/Size/RBSP
+        goto failed;
+      for (int i = 7; i < 23; i++) {
+        if (head[i] != frame_number_sei_guid[i - 7]) {
+          goto failed;
+        }
+      }
+      // Read the entire payload
+      for (unsigned int i = 0; i < payload_size - 16; i++)
+        side_data.push_back(head[i + 23]);
+      return payload_size;
+    }
+  }
+failed:
+  return -1;
+}
+
+const char* H264DXVADecoderImpl::ImplementationName() const {
+  return "OWTD3D11VA";
+}
+
+bool H264DXVADecoderImpl::IsInitialized() const {
+  return decoder_ctx != nullptr;
+}
+
+void H264DXVADecoderImpl::ReportInit() {
+  if (has_reported_init_)
+    return;
+  RTC_HISTOGRAM_ENUMERATION("WebRTC.Video.H264DXVADecoderImpl.Event",
+                            kH264DecoderEventInit,
+                            kH264DecoderEventMax);
+  has_reported_init_ = true;
+}
+
+void H264DXVADecoderImpl::ReportError() {
+  if (has_reported_error_)
+    return;
+  RTC_HISTOGRAM_ENUMERATION("WebRTC.Video.H264DXVADecoderImpl.Event",
+                            kH264DecoderEventError,
+                            kH264DecoderEventMax);
+  has_reported_error_ = true;
+}
+
+std::unique_ptr<H264DXVADecoderImpl> H264DXVADecoderImpl::Create(
+    cricket::VideoCodec format) {
+  return absl::make_unique<H264DXVADecoderImpl>(nullptr);
+}
+
+}  // namespace base
+}  // namespace owt

--- a/talk/owt/sdk/base/win/d3d11va_h264_decoder.h
+++ b/talk/owt/sdk/base/win/d3d11va_h264_decoder.h
@@ -1,0 +1,84 @@
+// Copyright (C) <2020> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OWT_BASE_WIN_D3D11VA_H264_DECODER_H_
+#define OWT_BASE_WIN_D3D11VA_H264_DECODER_H_
+
+#include <map>
+#include <memory>
+#include "modules/video_coding/codecs/h264/include/h264.h"
+#include <unordered_map>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/error.h>
+}  // extern "C"
+
+#include <atlbase.h>
+#include <d3d11.h>
+#include <dxgi1_2.h>
+
+// For dxva only.
+#include <libavcodec/d3d11va.h>
+#include <libavutil/hwcontext_d3d11va.h>
+
+#include "talk/owt/sdk/base/win/d3d11device.h"
+#include "talk/owt/sdk/base/win/d3dnativeframe.h"
+#include "talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h"
+
+namespace owt {
+namespace base {
+
+class H264DXVADecoderImpl : public webrtc::H264Decoder {
+ public:
+  static std::unique_ptr<H264DXVADecoderImpl> Create(
+      cricket::VideoCodec format);
+  H264DXVADecoderImpl(ID3D11Device* external_device);
+  ~H264DXVADecoderImpl() override;
+
+  int32_t InitDecode(const webrtc::VideoCodec* codec_settings,
+                     int32_t number_of_cores) override;
+  int32_t Release() override;
+
+  int32_t RegisterDecodeCompleteCallback(
+      webrtc::DecodedImageCallback* callback) override;
+
+  int32_t Decode(const webrtc::EncodedImage& input_image,
+                 bool /*missing_frames*/,
+                 int64_t render_time_ms = -1) override;
+
+  const char* ImplementationName() const override;
+
+ private:
+  bool IsInitialized() const;
+  int InitHwContext(AVCodecContext* ctx, const enum AVHWDeviceType type);
+  int PrepareHwDecoder(webrtc::VideoCodecType codec_type);
+  // Reports statistics with histograms.
+  void ReportInit();
+  void ReportError();
+  int64_t GetSideData(const uint8_t* frame_data, size_t frame_length, std::vector<uint8_t>& side_data);
+  webrtc::DecodedImageCallback* decoded_image_callback_;
+
+  bool has_reported_init_;
+  bool has_reported_error_;
+
+  // 
+  CComPtr<ID3D11Device> d3d11_device_;
+  CComPtr<ID3D11DeviceContext> d3d11_device_context_;
+  CComPtr<ID3D11VideoDevice> d3d11_video_device_;
+  CComPtr<ID3D11VideoContext> d3d11_video_context_;
+  std::unique_ptr<D3D11VAHandle> surface_handle_;
+  std::vector<uint8_t> current_side_data_;
+  std::unordered_map<uint32_t, std::vector<uint8_t>> side_data_list_;
+  AVBufferRef* hw_device_ctx = nullptr;
+  AVCodecContext* decoder_ctx = nullptr;
+  AVCodec* decoder = nullptr;
+};
+
+}  // namespace base
+}  // namespace owt
+
+#endif  // OWT_BASE_WIN_D3D11VA_H264_DECODER_H_

--- a/talk/owt/sdk/base/win/d3d_allocator.h
+++ b/talk/owt/sdk/base/win/d3d_allocator.h
@@ -66,7 +66,7 @@ public:
     virtual IDirect3DDeviceManager9* GetDeviceManager()
     {
         return m_manager;
-    }
+    };
 
     virtual mfxStatus LockFrame(mfxMemId mid, mfxFrameData *ptr);
     virtual mfxStatus UnlockFrame(mfxMemId mid, mfxFrameData *ptr);

--- a/talk/owt/sdk/base/win/msdkvideobase.cc
+++ b/talk/owt/sdk/base/win/msdkvideobase.cc
@@ -67,8 +67,11 @@ MSDKFactory* MSDKFactory::Get() {
 
 MFXVideoSession* MSDKFactory::InternalCreateSession() {
   mfxStatus sts = MFX_ERR_NONE;
-  mfxIMPL impl = MFX_IMPL_HARDWARE_ANY;
-  mfxVersion version = {{3, 1}};
+  mfxIMPL impl = MFX_IMPL_HARDWARE_ANY | MFX_IMPL_VIA_D3D11;
+
+  mfxVersion version;
+  version.Major = 1;
+  version.Minor = 0;
 
   MFXVideoSession* session = new MFXVideoSession();
   if (!session)
@@ -146,11 +149,11 @@ bool MSDKFactory::LoadEncoderPlugin(uint32_t codec_id,
   mfxStatus sts = MFX_ERR_NONE;
   switch (codec_id) {
     case MFX_CODEC_HEVC:
-      sts = MFXVideoUSER_Load(*session, &MFX_PLUGINID_HEVCE_GACC, 1);
+      sts = MFXVideoUSER_Load(*session, &MFX_PLUGINID_HEVCE_HW, 1);
       if (sts != MFX_ERR_NONE) {
         return false;
       }
-      *plugin_id = MFX_PLUGINID_HEVCE_GACC;
+      *plugin_id = MFX_PLUGINID_HEVCE_HW;
       break;
     case MFX_CODEC_AVC:
       break;

--- a/talk/owt/sdk/base/win/msdkvideobase.h
+++ b/talk/owt/sdk/base/win/msdkvideobase.h
@@ -14,6 +14,8 @@
 #include <mfxvideo++.h>
 #include <mfxplugin++.h>
 #include <mfxvp8.h>
+#include <memory>
+
 #include "msdkcommon.h"
 #include "sysmem_allocator.h"
 
@@ -32,14 +34,17 @@ class MSDKFactory {
   MFXVideoSession* CreateSession();
 
   void DestroySession(MFXVideoSession* session);
-  
-  MFXVideoSession* GetMainSession();
 
-  bool LoadDecoderPlugin(uint32_t codec_id, MFXVideoSession* session, mfxPluginUID* plugin_id);
-  bool LoadEncoderPlugin(uint32_t codec_id, MFXVideoSession* session, mfxPluginUID* plugin_id);
+  bool LoadDecoderPlugin(uint32_t codec_id,
+                         MFXVideoSession* session,
+                         mfxPluginUID* plugin_id);
+  bool LoadEncoderPlugin(uint32_t codec_id,
+                         MFXVideoSession* session,
+                         mfxPluginUID* plugin_id);
   void UnloadMSDKPlugin(MFXVideoSession* session, mfxPluginUID* plugin_id);
 
-  static std::shared_ptr<D3DFrameAllocator> CreateFrameAllocator(IDirect3DDeviceManager9* d3d_manager);
+  static std::shared_ptr<D3DFrameAllocator> CreateFrameAllocator(
+      IDirect3DDeviceManager9* d3d_manager);
   static std::shared_ptr<SysMemFrameAllocator> CreateFrameAllocator();
   void MFETimeout(uint32_t timeout);
   uint32_t MFETimeout();
@@ -47,11 +52,9 @@ class MSDKFactory {
     // Returns the number of adapter associated with MSDK session, 0 for SW
     // session
     static mfxU32 GetNumber(mfxSession session, mfxIMPL implVia = 0) {
-      mfxU32 adapterNum = 0;             // default
+      mfxU32 adapter_num = 0;             // default
       mfxIMPL impl = MFX_IMPL_SOFTWARE;  // default in case no HW IMPL is found
 
-      // We don't care for error codes in further code; if something goes wrong
-      // we fall back to the default adapter
       if (session) {
         MFXQueryIMPL(session, &impl);
       } else {
@@ -67,31 +70,31 @@ class MSDKFactory {
       }
 
       // Extract the base implementation type
-      mfxIMPL baseImpl = MFX_IMPL_BASETYPE(impl);
+      mfxIMPL base_impl = MFX_IMPL_BASETYPE(impl);
 
       const struct {
         // Actual implementation
         mfxIMPL impl;
         // Adapter's number
-        mfxU32 adapterID;
+        mfxU32 adapter_id;
 
-      } implTypes[] = {{MFX_IMPL_HARDWARE, 0},
+      } impl_types[] = {{MFX_IMPL_HARDWARE, 0},
                        {MFX_IMPL_SOFTWARE, 0},
                        {MFX_IMPL_HARDWARE2, 1},
                        {MFX_IMPL_HARDWARE3, 2},
                        {MFX_IMPL_HARDWARE4, 3}};
 
       // Get corresponding adapter number
-      for (mfxU8 i = 0; i < sizeof(implTypes) / sizeof(*implTypes); i++) {
-        if (implTypes[i].impl == baseImpl) {
-          adapterNum = implTypes[i].adapterID;
+      for (mfxU8 i = 0; i < sizeof(impl_types) / sizeof(*impl_types); i++) {
+        if (impl_types[i].impl == base_impl) {
+          adapter_num = impl_types[i].adapter_id;
           break;
         }
       }
-
-      return adapterNum;
+      return adapter_num;
     }
- };
+  };
+
  protected:
   MSDKFactory();
   bool Init();

--- a/talk/owt/sdk/base/win/msdkvideodecoderfactory.cc
+++ b/talk/owt/sdk/base/win/msdkvideodecoderfactory.cc
@@ -11,11 +11,12 @@
 #include "talk/owt/sdk/base/codecutils.h"
 #include "talk/owt/sdk/base/win/msdkvideodecoderfactory.h"
 #include "talk/owt/sdk/base/win/msdkvideodecoder.h"
+#include "talk/owt/sdk/base/win/d3d11va_h264_decoder.h"
 
 namespace owt {
 namespace base {
 
-MSDKVideoDecoderFactory::MSDKVideoDecoderFactory() {
+MSDKVideoDecoderFactory::MSDKVideoDecoderFactory(ID3D11Device* d3d11_device_external) {
   supported_codec_types_.clear();
   
   supported_codec_types_.push_back(webrtc::kVideoCodecVP8);
@@ -31,6 +32,7 @@ MSDKVideoDecoderFactory::MSDKVideoDecoderFactory() {
     supported_codec_types_.push_back(webrtc::kVideoCodecH265);
   }
 #endif
+  external_device_ = d3d11_device_external;
 }
 
 MSDKVideoDecoderFactory::~MSDKVideoDecoderFactory() {
@@ -48,6 +50,8 @@ std::unique_ptr<webrtc::VideoDecoder> MSDKVideoDecoderFactory::CreateVideoDecode
   } else if (absl::EqualsIgnoreCase(format.name, cricket::kH265CodecName)) {
     return MSDKVideoDecoder::Create(cricket::VideoCodec(format));
 #endif
+  } else if (absl::EqualsIgnoreCase(format.name, cricket::kH264CodecName)) {
+    return owt::base::H264DXVADecoderImpl::Create(cricket::VideoCodec(format));
   }
 
   return nullptr;

--- a/talk/owt/sdk/base/win/msdkvideodecoderfactory.h
+++ b/talk/owt/sdk/base/win/msdkvideodecoderfactory.h
@@ -5,6 +5,7 @@
 #ifndef OWT_BASE_WIN_MSDKVIDEODECODERFACTORY_H_
 #define OWT_BASE_WIN_MSDKVIDEODECODERFACTORY_H_
 
+#include <d3d11.h>
 #include <vector>
 
 #include "webrtc/api/video_codecs/sdp_video_format.h"
@@ -16,7 +17,7 @@ namespace base {
 // Declaration of MSDK based decoder factory.
 class MSDKVideoDecoderFactory : public webrtc::VideoDecoderFactory {
  public:
-  MSDKVideoDecoderFactory();
+  MSDKVideoDecoderFactory(ID3D11Device* d3d11_device_external);
   virtual ~MSDKVideoDecoderFactory();
 
   // VideoDecoderFactory implementation
@@ -26,6 +27,7 @@ class MSDKVideoDecoderFactory : public webrtc::VideoDecoderFactory {
       const webrtc::SdpVideoFormat& format) override;
  private:
   std::vector<webrtc::VideoCodecType> supported_codec_types_;
+  ID3D11Device* external_device_ = nullptr;
 };
 }  // namespace base
 }  // namespace owt

--- a/talk/owt/sdk/base/win/videorendererd3d11.cc
+++ b/talk/owt/sdk/base/win/videorendererd3d11.cc
@@ -1,0 +1,227 @@
+// Copyright (C) <2018> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "talk/owt/sdk/base/win/videorendererd3d11.h"
+#include "rtc_base/logging.h"
+#include "talk/owt/sdk/base/nativehandlebuffer.h"
+#include "talk/owt/sdk/base/win/d3d11device.h"
+#include "talk/owt/sdk/base/win/d3dnativeframe.h"
+#include "talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h"
+#include "webrtc/common_video/libyuv/include/webrtc_libyuv.h"
+
+using namespace rtc;
+namespace owt {
+namespace base {
+
+WebrtcVideoRendererD3D11Impl::WebrtcVideoRendererD3D11Impl(HWND wnd)
+    : wnd_(wnd), width_(0), height_(0) {
+  CreateDXGIFactory(__uuidof(IDXGIFactory2), (void**)(&dxgi_factory_));
+}
+
+void WebrtcVideoRendererD3D11Impl::Destroy() {}
+
+void WebrtcVideoRendererD3D11Impl::Resize(size_t width, size_t height) {}
+
+mfxStatus WebrtcVideoRendererD3D11Impl::CreateOrUpdateContext(
+  ID3D11Device* device,
+  ID3D11VideoDevice* video_device,
+  ID3D11VideoContext* context, 
+  mfxU16 width, 
+  mfxU16 height) {
+  if (!wnd_ || !dxgi_factory_.p || !IsWindow(wnd_))
+    return MFX_ERR_NOT_FOUND;
+
+  if (device == nullptr || video_device == nullptr
+      ||context == nullptr || width == 0 || height == 0)
+    return MFX_ERR_DEVICE_FAILED;
+
+  if (device != d3d11_device_ || context != d3d11_video_context_) {
+    // If device get changed, re-create the swap chain.
+    d3d11_device_ = device;
+    d3d11_video_device_ = video_device;
+    d3d11_video_context_ = context;
+
+    swap_chain_for_hwnd_.Release();
+
+    DXGI_SWAP_CHAIN_DESC1 swap_chain_desc = {0};
+    FillSwapChainDesc(swap_chain_desc);
+
+    HRESULT hr = dxgi_factory_->CreateSwapChainForHwnd(
+        d3d11_device_, wnd_, &swap_chain_desc, nullptr, nullptr,
+        &swap_chain_for_hwnd_);
+
+    if (FAILED(hr)) {
+      return MFX_ERR_DEVICE_FAILED;
+    }
+
+    D3D11_VIDEO_PROCESSOR_CONTENT_DESC content_desc;
+    MSDK_ZERO_MEMORY(content_desc);
+
+    // Non-scaling
+    content_desc.InputFrameFormat = D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE;
+    content_desc.InputFrameRate.Numerator = 60;
+    content_desc.InputFrameRate.Denominator = 1;
+    content_desc.InputWidth = width;
+    content_desc.InputHeight = height;
+    content_desc.OutputWidth = width;
+    content_desc.OutputHeight = height;
+    content_desc.OutputFrameRate.Numerator = 60;
+    content_desc.OutputFrameRate.Denominator = 1;
+    content_desc.Usage = D3D11_VIDEO_USAGE_PLAYBACK_NORMAL;
+
+    video_processors_enum_.Release();
+    hr = d3d11_video_device_->CreateVideoProcessorEnumerator(
+        &content_desc, &video_processors_enum_);
+    if (FAILED(hr)) {
+      return MFX_ERR_DEVICE_FAILED;
+    }
+  }
+
+  return MFX_ERR_NONE;
+}
+
+void WebrtcVideoRendererD3D11Impl::FillSwapChainDesc(
+    DXGI_SWAP_CHAIN_DESC1& scd) {
+  scd.Width = scd.Height = 0;  // automatic sizing.
+  scd.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+  scd.Stereo = false;
+  scd.SampleDesc.Count = 1;  // no multi-sampling
+  scd.SampleDesc.Quality = 0;
+  scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+  scd.BufferCount = 2;
+  scd.Scaling = DXGI_SCALING_STRETCH;
+  scd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+  scd.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+}
+
+mfxStatus WebrtcVideoRendererD3D11Impl::CreateVideoProcessor(mfxU16 width,
+    mfxU16 height) {
+  if (width == 0 || height == 0 || d3d11_video_device_ == nullptr)
+    return MFX_ERR_DEVICE_FAILED;
+
+  video_processor_.Release();
+  HRESULT hr = d3d11_video_device_->CreateVideoProcessor(video_processors_enum_, 0,
+                                                 &video_processor_);
+  if (FAILED(hr)) {
+    return MFX_ERR_DEVICE_FAILED;
+  }
+
+  return MFX_ERR_NONE;
+}
+
+mfxStatus WebrtcVideoRendererD3D11Impl::RenderFrame(ID3D11Texture2D* texture) {
+  if (texture == nullptr || !swap_chain_for_hwnd_.p
+      || !d3d11_video_device_ || !d3d11_video_context_)
+    return MFX_ERR_NULL_PTR;
+
+  mfxStatus sts = CreateVideoProcessor(width_, height_);
+  if (sts != MFX_ERR_NONE)
+    return sts;
+
+  CComPtr<ID3D11Texture2D> current_back_buffer;
+
+  HRESULT hr = swap_chain_for_hwnd_->GetBuffer(
+      0, __uuidof(ID3D11Texture2D), (void**)&current_back_buffer.p);
+  if (FAILED(hr))
+    return MFX_ERR_DEVICE_FAILED;
+
+  // Create output view and input view
+  D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC output_view_desc;
+  MSDK_ZERO_MEMORY(output_view_desc);
+
+  output_view_desc.ViewDimension = D3D11_VPOV_DIMENSION_TEXTURE2D;
+  output_view_desc.Texture2D.MipSlice = 0;
+
+  hr = d3d11_video_device_->CreateVideoProcessorOutputView(
+      current_back_buffer, video_processors_enum_, &output_view_desc,
+      &output_view_.p);
+
+  if (FAILED(hr))
+    return MFX_ERR_DEVICE_FAILED;
+
+  D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC input_view_desc;
+  MSDK_ZERO_MEMORY(input_view_desc);
+  input_view_desc.FourCC = 0;
+  input_view_desc.ViewDimension = D3D11_VPIV_DIMENSION_TEXTURE2D;
+  input_view_desc.Texture2D.MipSlice = 0;
+  input_view_desc.Texture2D.ArraySlice = 0;
+
+  hr = d3d11_video_device_->CreateVideoProcessorInputView(
+      texture, video_processors_enum_, &input_view_desc, &input_view_.p);
+  if (FAILED(hr))
+    return MFX_ERR_DEVICE_FAILED;
+
+  // Blit NV12 surface to RGB back buffer here.
+  RECT rect = {0, 0, width_, height_};
+  D3D11_VIDEO_PROCESSOR_STREAM stream;
+  MSDK_ZERO_MEMORY(stream);
+  stream.Enable = true;
+  stream.OutputIndex = 0;
+  stream.InputFrameOrField = 0;
+  stream.PastFrames = 0;
+  stream.ppPastSurfaces = nullptr;
+  stream.ppFutureSurfaces = nullptr;
+  stream.pInputSurface = input_view_;
+  stream.ppPastSurfacesRight = nullptr;
+  stream.ppFutureSurfacesRight = nullptr;
+  stream.pInputSurfaceRight = nullptr;
+
+  d3d11_video_context_->VideoProcessorSetStreamSourceRect(video_processor_, 0,
+                                                          true, &rect);
+  d3d11_video_context_->VideoProcessorSetStreamFrameFormat(
+      video_processor_, 0, D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE);
+
+  hr = d3d11_video_context_->VideoProcessorBlt(
+      video_processor_, output_view_, 0, 1, &stream);
+  if (FAILED(hr)) {
+    return MFX_ERR_NONE;
+  }
+
+  DXGI_PRESENT_PARAMETERS parameters = {0};
+  // TODO: handle device loss, etc. Need to find a way
+  // to inform decoder to recreate the d3d11 device/context.
+  hr = swap_chain_for_hwnd_->Present1(0, 0, &parameters);
+  return MFX_ERR_NONE;
+}
+
+void WebrtcVideoRendererD3D11Impl::OnFrame(
+    const webrtc::VideoFrame& video_frame) {
+  if (video_frame.video_frame_buffer()->type() ==
+      webrtc::VideoFrameBuffer::Type::kNative) {
+    D3D11Handle* native_handle =
+        reinterpret_cast<D3D11Handle*>(
+            reinterpret_cast<owt::base::NativeHandleBuffer*>(
+                video_frame.video_frame_buffer().get())
+                ->native_handle());
+
+    if (native_handle == nullptr)
+      return;
+
+    ID3D11Device* render_device = native_handle->d3d11_device;
+    ID3D11VideoDevice* render_video_device = native_handle->d3d11_video_device;
+    ID3D11Texture2D* texture = native_handle->texture;
+    ID3D11VideoContext* render_context = native_handle->context;
+
+    uint16_t width = video_frame.video_frame_buffer()->width();
+    uint16_t height = video_frame.video_frame_buffer()->height();
+
+    if (width == 0 || height == 0)
+      return;
+
+    if (render_device == nullptr || render_video_device == nullptr ||
+        wnd_ == nullptr || texture == nullptr)
+      return;
+
+	width_ = width;
+    height_ = height;
+    mfxStatus sts = CreateOrUpdateContext(render_device, render_video_device, render_context, width, height);
+    if (sts == MFX_ERR_NONE) {
+      RenderFrame(texture);
+    }
+  } else {  // I420 frame passed.
+  }
+  return;
+}
+}  // namespace base
+}  // namespace owt

--- a/talk/owt/sdk/base/win/videorendererd3d11.h
+++ b/talk/owt/sdk/base/win/videorendererd3d11.h
@@ -9,7 +9,6 @@
 #include <combaseapi.h>
 #include <d3d11.h>
 #include <dxgi1_2.h>
-#include "talk/owt/sdk/base/win/msdkcommon.h"
 #include "webrtc/api/video/video_frame.h"
 #include "webrtc/api/video/video_sink_interface.h"
 namespace owt {
@@ -24,12 +23,12 @@ class WebrtcVideoRendererD3D11Impl
  private:
   void Destroy();
   void Resize(size_t width, size_t height);
-  mfxStatus CreateOrUpdateContext(ID3D11Device* device,
+  bool CreateOrUpdateContext(ID3D11Device* device,
       ID3D11VideoDevice* video_device, ID3D11VideoContext* context,
-      mfxU16 width, mfxU16 height);
+      uint16_t width, uint16_t height);
   void FillSwapChainDesc(DXGI_SWAP_CHAIN_DESC1& scd);
-  mfxStatus CreateVideoProcessor(mfxU16 width, mfxU16 height);
-  mfxStatus RenderFrame(ID3D11Texture2D* texture);
+  bool CreateVideoProcessor(uint16_t width, uint16_t height);
+  bool RenderFrame(ID3D11Texture2D* texture);
 
   HWND wnd_ = nullptr;
   uint16_t width_ = 0;

--- a/talk/owt/sdk/base/win/videorendererd3d11.h
+++ b/talk/owt/sdk/base/win/videorendererd3d11.h
@@ -1,0 +1,52 @@
+// Copyright (C) <2020> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OWT_BASE_WIN_VIDEORENDERERD3D11_H
+#define OWT_BASE_WIN_VIDEORENDERERD3D11_H
+#include <windows.h>
+#include <atlbase.h>
+#include <combaseapi.h>
+#include <d3d11.h>
+#include <dxgi1_2.h>
+#include "talk/owt/sdk/base/win/msdkcommon.h"
+#include "webrtc/api/video/video_frame.h"
+#include "webrtc/api/video/video_sink_interface.h"
+namespace owt {
+namespace base {
+class WebrtcVideoRendererD3D11Impl
+    : public rtc::VideoSinkInterface<webrtc::VideoFrame> {
+ public:
+  WebrtcVideoRendererD3D11Impl(HWND wnd);
+  virtual void OnFrame(const webrtc::VideoFrame& frame) override;
+  virtual ~WebrtcVideoRendererD3D11Impl() { Destroy(); }
+
+ private:
+  void Destroy();
+  void Resize(size_t width, size_t height);
+  mfxStatus CreateOrUpdateContext(ID3D11Device* device,
+      ID3D11VideoDevice* video_device, ID3D11VideoContext* context,
+      mfxU16 width, mfxU16 height);
+  void FillSwapChainDesc(DXGI_SWAP_CHAIN_DESC1& scd);
+  mfxStatus CreateVideoProcessor(mfxU16 width, mfxU16 height);
+  mfxStatus RenderFrame(ID3D11Texture2D* texture);
+
+  HWND wnd_ = nullptr;
+  uint16_t width_ = 0;
+  uint16_t height_ = 0;
+
+  // Owner of the d3d11 device/context is decoder.
+  ID3D11Device* d3d11_device_ = nullptr;
+  ID3D11VideoDevice* d3d11_video_device_ = nullptr;
+  ID3D11VideoContext* d3d11_video_context_ = nullptr;
+
+  CComPtr<IDXGIFactory2> dxgi_factory_;
+  CComPtr<ID3D11VideoProcessorEnumerator> video_processors_enum_;
+  CComPtr<ID3D11VideoProcessor> video_processor_;
+  CComPtr<ID3D11VideoProcessorInputView> input_view_;
+  CComPtr<ID3D11VideoProcessorOutputView> output_view_;
+  CComPtr<IDXGISwapChain1> swap_chain_for_hwnd_;
+};
+}  // namespace base
+}  // namespace owt
+#endif  // OWT_BASE_WIN_VIDEORENDERERD3D11_H

--- a/talk/owt/sdk/include/cpp/owt/base/clock.h
+++ b/talk/owt/sdk/include/cpp/owt/base/clock.h
@@ -1,0 +1,29 @@
+// Copyright (C) <2018> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OWT_BASE_CLOCK_H_
+#define OWT_BASE_CLOCK_H_
+
+#include <stdint.h>
+
+namespace webrtc {
+class Clock;
+}  // namespace webrtc
+
+namespace owt {
+namespace base {
+
+/// A Wrapper of webrtc::Clock.
+class Clock {
+ public:
+  explicit Clock();
+  int64_t TimeInMilliseconds();
+
+ private:
+   webrtc::Clock* clock_;
+};
+
+}  // namespace base
+}  // namespace owt
+
+#endif  // OWT_BASE_CLOCK_H_

--- a/talk/owt/sdk/include/cpp/owt/base/clock.h
+++ b/talk/owt/sdk/include/cpp/owt/base/clock.h
@@ -20,7 +20,7 @@ class Clock {
   int64_t TimeInMilliseconds();
 
  private:
-   webrtc::Clock* clock_;
+  webrtc::Clock* clock_;
 };
 
 }  // namespace base

--- a/talk/owt/sdk/include/cpp/owt/base/commontypes.h
+++ b/talk/owt/sdk/include/cpp/owt/base/commontypes.h
@@ -8,6 +8,9 @@
 #include <unordered_map>
 namespace owt {
 namespace base {
+
+#define OWT_ENCODED_IMAGE_SIDE_DATA_SIZE_MAX 240
+
 /// Audio codec
 enum class AudioCodec : int {
   kPcmu = 1,   ///< g711 u-law

--- a/talk/owt/sdk/include/cpp/owt/base/connectionstats.h
+++ b/talk/owt/sdk/include/cpp/owt/base/connectionstats.h
@@ -98,7 +98,8 @@ struct VideoReceiverReport {
                       int32_t delay, std::string codec_name, int32_t jitter)
       : bytes_rcvd(bytes_rcvd), packets_rcvd(packets_rcvd), packets_lost(packets_lost)
       , fir_count(fir_count), pli_count(pli_count), nack_count(nack_count)
-      , frame_resolution_rcvd(Resolution(rcvd_frame_width, rcvd_frame_height)), framerate_output(framerate_output)
+      , frame_resolution_rcvd(Resolution(rcvd_frame_width, rcvd_frame_height))
+      , framerate_rcvd(framerate_rcvd), framerate_output(framerate_output)
       , delay(delay), codec_name(codec_name), jitter(jitter) {}
   /// Video bytes received
   int64_t bytes_rcvd;

--- a/talk/owt/sdk/include/cpp/owt/base/cursorutils.h
+++ b/talk/owt/sdk/include/cpp/owt/base/cursorutils.h
@@ -1,0 +1,51 @@
+// Copyright (C) <2018> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OWT_CURSORUTILS_H_
+#define OWT_CURSORUTILS_H_
+
+#include <string>
+
+namespace owt {
+namespace base {
+
+struct Point {
+  long x;
+  long y;
+};
+
+struct CursorRect {
+  long left;
+  long top;
+  long right;
+  long bottom;
+};
+
+struct CursorInfo {
+  bool visible;
+  bool no_shape_update;
+  bool colored;
+  Point frame_pos;
+  Point hotspot;
+  CursorRect src_rect;
+  CursorRect dst_rect;
+  long width;
+  long height;
+  long pitch;
+  uint8_t* cursor_buffer;
+};
+
+class CursorUtils {
+ public:
+
+  // Format is:
+  //  {visible: true, colored: true, framePos: {x, y}, hotspot: {x, y},
+  //     srcRect: {left: x, top: y, right: z, bottom: v},
+  //     dstRect: {left: x, top: y, right: z, bottom: v},
+  //     width: x,  height: y, pitch: z,
+  //     cursorData: xxxxxxxxxxxxxx}  //base64 encoded data.
+  static std::string GetJsonForCursorInfo(CursorInfo& cursor_info);
+};
+}
+}
+#endif  // OWT_CURSORUTILS_H_

--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -12,7 +12,6 @@
 #include "owt/base/macros.h"
 #include "owt/base/options.h"
 #include "owt/base/videoencoderinterface.h"
-//#include "owt/base/videorendererinterface.h"
 #include "owt/base/audioplayerinterface.h"
 namespace webrtc {
 class MediaStreamInterface;

--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -55,7 +55,7 @@ class StreamObserver {
 class WebrtcVideoRendererImpl;
 class WebrtcAudioRendererImpl;
 #if defined(WEBRTC_WIN)
-class WebrtcVideoRendererD3D9Impl;
+class WebrtcVideoRendererD3D11Impl;
 #endif
 /// Base class of all streams with media stream
 class Stream {
@@ -131,7 +131,9 @@ class Stream {
   WebrtcVideoRendererImpl* renderer_impl_;
   WebrtcAudioRendererImpl* audio_renderer_impl_;
 #if defined(WEBRTC_WIN)
-  WebrtcVideoRendererD3D9Impl* d3d9_renderer_impl_;
+#if defined(OWT_USE_MSDK)
+  WebrtcVideoRendererD3D11Impl* d3d11_renderer_impl_;
+#endif
 #endif
   StreamSourceInfo source_;
 
@@ -231,12 +233,13 @@ class LocalStream : public Stream {
     with video encoder interface.
     @param parameters Parameters for creating the stream. The stream will not
     be impacted if changing parameters after it is created.
-    @param encoder Pointer to an instance implementing VideoEncoderInterface.
+    @param encoder Pointer to an instance of EncodedStreamProvider.
     @return Pointer to created LocalStream.
   */
   static std::shared_ptr<LocalStream> Create(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
-      VideoEncoderInterface* encoder);
+      std::shared_ptr<EncodedStreamProvider> encoder);
+#if defined(WEBRTC_WIN)
   /**
     @brief Initialize a local screen stream with parameters.
     @param parameters Parameters for creating the stream. The stream will
@@ -248,7 +251,7 @@ class LocalStream : public Stream {
   static std::shared_ptr<LocalStream> Create(
       std::shared_ptr<LocalDesktopStreamParameters> parameters,
       std::unique_ptr<LocalScreenStreamObserver> observer);
-
+#endif
  protected:
   explicit LocalStream(const LocalCameraStreamParameters& parameters,
                        int& error_code);
@@ -260,7 +263,7 @@ class LocalStream : public Stream {
       std::unique_ptr<VideoFrameGeneratorInterface> framer);
   explicit LocalStream(
       std::shared_ptr<LocalCustomizedStreamParameters> parameters,
-      VideoEncoderInterface* encoder);
+      std::shared_ptr<EncodedStreamProvider> encoder);
   explicit LocalStream(std::shared_ptr<LocalDesktopStreamParameters> parameters,
                        std::unique_ptr<LocalScreenStreamObserver> observer);
 

--- a/talk/owt/sdk/include/cpp/owt/base/videoencoderinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/videoencoderinterface.h
@@ -4,21 +4,157 @@
 #ifndef OWT_BASE_VIDEOENCODERINTERFACE_H_
 #define OWT_BASE_VIDEOENCODERINTERFACE_H_
 #include <memory>
+#include <mutex>
 #include <vector>
 #include "owt/base/commontypes.h"
+
 namespace owt {
 namespace base {
+
+struct EncodedImageMetaData {
+  // ctor
+  EncodedImageMetaData()
+        : picture_id(0),
+        last_fragment(true),
+        capture_timestamp(0),
+        encoding_start(0),
+        encoding_end(0),
+        side_data(nullptr),
+        side_data_length(0) {}
+  // dtor
+  ~EncodedImageMetaData() {
+    if (side_data) {
+      delete side_data;
+      side_data = nullptr;
+    }
+  }
+  // The picture id of frame.
+  uint16_t picture_id;
+  // Indicate if current data is the end of a frame which might be sent
+  // slice-by-slice
+  bool last_fragment = true;
+  // Capture timestamp
+  uint64_t capture_timestamp;
+  // Start encoding time in ms
+  uint64_t encoding_start;
+  // End encoding time in ms
+  uint64_t encoding_end;
+  // Allocate sidedata. If allocated already, will free it first.
+  // For OWT, maximum allowed size is 240 bytes.
+  uint8_t* encoded_image_sidedata_new(size_t data_length) {
+    if (data_length > OWT_ENCODED_IMAGE_SIDE_DATA_SIZE_MAX) {  // do nothing
+      return side_data;
+    }
+    if (side_data) {
+      delete side_data;
+    }
+    side_data = new uint8_t[data_length];
+    side_data_length = data_length;
+    return side_data;
+  }
+  // Get side data ptr.
+  uint8_t* encoded_image_sidedata_get() const { return side_data; }
+  // Get sidedata size.
+  size_t encoded_image_sidedata_size() const { return side_data_length; }
+  // Free sidedata.
+  void encoded_image_sidedata_free() {
+    if (side_data) {
+      delete side_data;
+      side_data = nullptr;
+      side_data_length = 0;
+    }
+  }
+ private:
+  // Side data
+  uint8_t* side_data = nullptr;
+  // Side data size
+  size_t side_data_length = 0;
+};
+
+class EncodedStreamProviderSink {
+ public:
+  // Invoked by EncodedStream
+  virtual void OnStreamProviderFrame(const std::vector<uint8_t>& buffer,
+                       const EncodedImageMetaData& meta_data) = 0;
+};
+
+// Registered to EncodedStreamProvider to receive events from encoder.
+class EncoderObserver {
+ public:
+  virtual void OnStarted() = 0;
+
+  virtual void OnStopped() = 0;
+
+  virtual void OnKeyFrameRequest() = 0;
+
+  virtual void OnRateUpdate(uint64_t bitrate_bps, uint32_t frame_rate) = 0;
+};
+
+// Encoder event callback interface
+class EncoderEventCallback {
+ public:
+  virtual void StartStreaming() = 0;
+
+  virtual void StopStreaming() = 0;
+
+  virtual void RequestKeyFrame() = 0;
+
+  virtual void RequestRateUpdate(uint64_t bitrate_bps, uint32_t frame_rate) = 0;
+};
+
+/**
+  @brief Encoded stream provider
+  */
+class EncodedStreamProvider final : public std::enable_shared_from_this<EncodedStreamProvider> {
+ public:
+  static std::shared_ptr<EncodedStreamProvider> Create();
+
+  virtual ~EncodedStreamProvider() {}
+
+  void SendOneFrame(const std::vector<uint8_t>& buffer,
+                    const EncodedImageMetaData& meta_data);
+
+  // Not intented to be called by application. May move to private later.
+  void RequestKeyFrame();
+
+  // Not intented to be called by application. May move to private later.
+  void RequestRateUpdate(uint64_t bitrate_bps, uint32_t frame_rate);
+
+  void StartStreaming();
+
+  void StopStreaming();
+
+  void AddSink(EncodedStreamProviderSink* sink);
+
+  void RemoveSink();
+
+  // Called by encoded stream capturer only.
+  void RegisterEncoderObserver(EncoderObserver& observer);
+
+  void DeRegisterEncoderObserver(EncoderObserver& observer);
+
+ protected:
+  EncodedStreamProvider() {}
+
+ private:
+  bool streaming_started_ = false;
+  EncodedStreamProviderSink* sink_ = nullptr;
+  std::vector<std::reference_wrapper<EncoderObserver>>
+      stream_provider_observers_;
+  mutable std::mutex observer_mutex_;
+};
+
 /**
   @brief Video encoder interface
   @details Internal webrtc encoder will request from this
    interface when it needs one complete encoded frame.
 */
 class VideoEncoderInterface {
-  public:
+ public:
   /**
    @brief Destructor
    */
-   virtual ~VideoEncoderInterface() {}
+  virtual ~VideoEncoderInterface() {}
   /**
    @brief Initialize the customized video encoder
    @param resolution Resolution of frame to be encoded.
@@ -30,21 +166,28 @@ class VideoEncoderInterface {
    false on failing to init the encoder context.
    */
   virtual bool InitEncoderContext(Resolution& resolution,
-      uint32_t fps, uint32_t bitrate_kbps, VideoCodec video_codec) = 0;
+                                  uint32_t fps,
+                                  uint32_t bitrate_kbps,
+                                  VideoCodec video_codec) = 0;
 #ifdef WEBRTC_ANDROID
   virtual uint32_t EncodeOneFrame(bool key_frame, uint8_t** data) = 0;
 #else
   /**
    @brief Retrieve byte buffer from encoder that holds one complete frame.
-   @details The buffer is provided by caller and EncodedOneFrame implementation should
-   copy encoded data to this buffer. After return, the caller owns the buffer and
-   VideoEncoderInterface implementation should not assume the buffer valid.
+   @details The buffer is provided by caller and EncodedOneFrame implementation
+   should copy encoded data to this buffer. After return, the caller owns the
+   buffer and VideoEncoderInterface implementation should not assume the buffer
+   valid.
    @param buffer Output buffer that holds the encoded data.
-   @param key_frame Indicates whether we're requesting an AU representing an key frame.
-   @return Returns true if the encoder successfully returns one frame; returns false
-   if the encoder fails to encode one frame.
+   @param key_frame Indicates whether we're requesting an AU representing an key
+   frame.
+   @param meta_data The returned metadata of the encoded frame.
+   @return Returns true if the encoder successfully returns one frame; returns
+   false if the encoder fails to encode one frame.
    */
-  virtual bool EncodeOneFrame(std::vector<uint8_t>& buffer, bool key_frame) = 0;
+  virtual bool EncodeOneFrame(std::vector<uint8_t>& buffer,
+                              bool key_frame,
+                              EncodedImageMetaData& meta_data) = 0;
 #endif
   /**
    @brief Release the resources that current encoder holds.
@@ -58,6 +201,6 @@ class VideoEncoderInterface {
    */
   virtual VideoEncoderInterface* Copy() = 0;
 };
-}
-}
+}  // namespace base
+}  // namespace owt
 #endif  // OWT_BASE_VIDEOENCODERINTERFACE_H_

--- a/talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h
@@ -6,7 +6,8 @@
 #include <memory>
 #include "owt/base/commontypes.h"
 #if defined(WEBRTC_WIN)
-#include <Windows.h>
+#include <d3d11.h>
+#include <windows.h>
 #endif
 #if defined(WEBRTC_LINUX)
 #include <X11/Xlib.h>
@@ -16,20 +17,27 @@ namespace base {
 enum class VideoBufferType {
   kI420,
   kARGB,
+  kD3D11Handle,
 };
 enum class VideoRendererType {
   kI420,
   kARGB,
+  kD3D11Handle,
 };
 /// Video buffer and its information
 struct VideoBuffer {
-  /// Video buffer
-  uint8_t* buffer;
+  /// Video buffer. If is native, 
+   void* buffer;
   /// Resolution for the Video buffer
   Resolution resolution;
   // Buffer type
   VideoBufferType type;
-  ~VideoBuffer() { delete[] buffer; }
+  ~VideoBuffer() {
+    if (type != VideoBufferType::kD3D11Handle)
+      delete[] buffer;
+    else
+      delete buffer;
+  }
 };
 /// VideoRenderWindow wraps a native Window handle
 #if defined(WEBRTC_WIN)
@@ -79,6 +87,23 @@ class VideoRendererInterface {
   /// Render type that indicates the VideoBufferType the renderer would receive.
   virtual VideoRendererType Type() = 0;
 };
+#if defined(WEBRTC_WIN)
+struct D3D11Handle {
+  ID3D11Texture2D* texture;
+  ID3D11Device* d3d11_device;
+  ID3D11VideoDevice* d3d11_video_device;
+  ID3D11VideoContext* context;
+};
+struct D3D11VAHandle {
+  ID3D11Texture2D* texture;
+  int array_index;
+  ID3D11Device* d3d11_device;
+  ID3D11VideoDevice* d3d11_video_device;
+  ID3D11VideoContext* context;
+  uint8_t side_data[OWT_ENCODED_IMAGE_SIDE_DATA_SIZE_MAX];
+  size_t side_data_size;
+};
+#endif
 }  // namespace base
 }  // namespace owt
 #endif  // OWT_BASE_VIDEORENDERERINTERFACE_H_

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -170,6 +170,23 @@ class P2PClient final
    */
   void Send(const std::string& target_id,
             const std::string& message,
+            bool is_reliable,
+            std::function<void()> on_success,
+            std::function<void(std::unique_ptr<Exception>)> on_failure);
+   /**
+    @brief Send a message to remote client on text message channel.
+    @param target_id Remote user's ID.
+    @param message The message to be sent.
+    @param on_success Success callback will be invoked if send
+                      deny event successfully.
+    @param on_failure Failure callback will be invoked if one of
+    the following cases happened.
+    1. P2PClient is disconnected from the server.
+    2. Target ID is null or target user is offline.
+    3. There is no WebRTC session with target user.
+    */
+  void Send(const std::string& target_id,
+            const std::string& message,
             std::function<void()> on_success,
             std::function<void(std::unique_ptr<Exception>)> on_failure);
   /**
@@ -215,7 +232,7 @@ class P2PClient final
                  std::function<void()> on_success,
                  std::function<void(std::unique_ptr<Exception>)> on_failure);
   std::shared_ptr<P2PPeerConnectionChannel> GetPeerConnectionChannel(
-      const std::string& target_id);
+      const std::string& target_id, bool replace = false);
   bool IsPeerConnectionChannelCreated(const std::string& target_id);
   owt::base::PeerConnectionChannelConfiguration GetPeerConnectionChannelConfiguration();
   // Queue for callbacks and events. Shared among P2PClient and all of it's


### PR DESCRIPTION
D3D11 renderer does not need MSDK to be included. Removing the headers and some legacy MSDK type usage in its implementation.