### PR TITLE
Revert "Fix an race condition on accessing ConferenceSocketSignalingChannel's observers."

### DIFF
--- a/talk/owt/sdk/conference/conferenceclient.cc
+++ b/talk/owt/sdk/conference/conferenceclient.cc
@@ -180,6 +180,7 @@ ConferenceClient::ConferenceClient(
           webrtc::TaskQueueFactory::Priority::NORMAL));
 }
 ConferenceClient::~ConferenceClient() {
+  signaling_channel_->RemoveObserver(*this);
 }
 void ConferenceClient::AddObserver(ConferenceClientObserver& observer) {
   const std::lock_guard<std::mutex> lock(observer_mutex_);
@@ -742,7 +743,6 @@ void ConferenceClient::Leave(
     subscribe_pcs_.clear();
   }
   signaling_channel_->Disconnect(RunInEventQueue(on_success), on_failure);
-  signaling_channel_->RemoveObserver(*this);
 }
 void ConferenceClient::GetConnectionStats(
     const std::string& session_id,

--- a/talk/owt/sdk/conference/conferencesocketsignalingchannel.h
+++ b/talk/owt/sdk/conference/conferencesocketsignalingchannel.h
@@ -126,7 +126,6 @@ class ConferenceSocketSignalingChannel
       const owt::base::Resolution& resolution);
   sio::client* socket_client_;
   std::vector<ConferenceSocketSignalingChannelObserver*> observers_;
-  std::mutex observer_mutex_;
   std::function<void(std::unique_ptr<Exception>)>
       connect_failure_callback_;
   std::function<void()> disconnect_complete_;


### PR DESCRIPTION
Reverts open-webrtc-toolkit/owt-client-native#359 (22f9ecc5690991fde1082534abaccdfd1592f4a7)

CI fails after merging this change.