### PR TITLE
Before exiting the CustomizedFramesThread, call the Cleanup()

### DIFF
--- a/talk/owt/sdk/base/customizedframescapturer.cc
+++ b/talk/owt/sdk/base/customizedframescapturer.cc
@@ -36,10 +36,12 @@ class CustomizedFramesCapturer::CustomizedFramesThread
   virtual void Run() {
     // Read the first frame and start the message pump. The pump runs until
     // Stop() is called externally or Quit() is called by OnMessage().
+    // Before returning, cleanup any thread-sensitive resources.
     if (capturer_) {
       capturer_->ReadFrame();
       rtc::Thread::Current()->Post(RTC_FROM_HERE, this);
       rtc::Thread::Current()->ProcessMessages(kForever);
+      capturer_->CleanupGenerator();
     }
     rtc::CritScope cs(&crit_);
     finished_ = true;
@@ -147,6 +149,12 @@ int32_t CustomizedFramesCapturer::StopCapture() {
   }
   capture_started_ = false;
   return 0;
+}
+
+void CustomizedFramesCapturer::CleanupGenerator() {
+  if (frame_generator_) {
+    frame_generator_->Cleanup();
+  }
 }
 
 bool CustomizedFramesCapturer::CaptureStarted() {

--- a/talk/owt/sdk/base/customizedframescapturer.h
+++ b/talk/owt/sdk/base/customizedframescapturer.h
@@ -70,6 +70,9 @@ class CustomizedFramesCapturer : public webrtc::VideoCaptureModule {
   // capacity should be greater or equal to |size|.
   virtual void AdjustFrameBuffer(uint32_t size);
 
+  // Tell generator to cleanup resources. Called by CustomizedFramesThread.
+  virtual void CleanupGenerator();
+
  private:
   class CustomizedFramesThread;  // Forward declaration, defined in .cc.
   int I420DataSize(int height, int stride_y, int stride_u, int stride_v);

--- a/talk/owt/sdk/include/cpp/owt/base/framegeneratorinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/framegeneratorinterface.h
@@ -74,6 +74,11 @@ class VideoFrameGeneratorInterface {
    @brief This function gets the video frame type of video frame generator.
    */
   virtual VideoFrameCodec GetType() = 0;
+  /**
+   @brief This function can perform any cleanup that must be done on the same thread as
+   GenerateNextFrame(). Default implementation provided for backwards compatibility.
+   */
+  virtual void Cleanup() {};
 };
 } // namespace base
 } // namespace owt

--- a/talk/owt/sdk/include/cpp/owt/base/framegeneratorinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/framegeneratorinterface.h
@@ -78,7 +78,7 @@ class VideoFrameGeneratorInterface {
    @brief This function can perform any cleanup that must be done on the same thread as
    GenerateNextFrame(). Default implementation provided for backwards compatibility.
    */
-  virtual void Cleanup() {};
+  virtual void Cleanup() {}
 };
 } // namespace base
 } // namespace owt


### PR DESCRIPTION
method on the FrameGeneratorInterface. Needed for generators that
use thread-senstive resources.

To ensure resources are constructed/destructed on a single thread,
use a bool that is set on the first call to GenerateNextFrame to
construct, and call destructs in the Cleanup() method. Cleanup() has
a default noop implementation for backwards-compatibility.

For [Issue 367](https://github.com/open-webrtc-toolkit/owt-client-native/issues/367)