### PR TITLE
Remove virtual from default implementation.

### DIFF
--- a/talk/owt/sdk/include/cpp/owt/base/framegeneratorinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/framegeneratorinterface.h
@@ -78,7 +78,7 @@ class VideoFrameGeneratorInterface {
    @brief This function can perform any cleanup that must be done on the same thread as
    GenerateNextFrame(). Default implementation provided for backwards compatibility.
    */
-  virtual void Cleanup() {}
+  void Cleanup() {}
 };
 } // namespace base
 } // namespace owt


### PR DESCRIPTION
Default implementation should not be virtual, would break any existing user's code if they don't add an explicit Cleanup, which was precisely what was to be avoided.