### PR TITLE
Disable loop range analysis when build with Xcode clang.

### DIFF
--- a/scripts/prepare_dev.py
+++ b/scripts/prepare_dev.py
@@ -36,7 +36,7 @@ patchList = [
     ('0005-Fixed-compile-issue-and-disable-thin-archive.patch', BUILD_PATH),
     ('0006-Adjusted-jni_generator.py-to-fit-OWT-code-structure.patch', BASE_PATH),
     ('0007-Fix-examples-path-error.patch', BUILD_PATH),
-    #('0009-Fix-compile-issue-for-linux-g-build.patch', BUILD_PATH),
+    ('0008-Disable-loop-range-analysis-when-build-with-Xcode-cl.patch', BUILD_PATH),
     ('0009-Export-WebRTC-symbols-on-iOS.patch', BUILD_PATH),
     ('0011-libjpeg_turbo-fix-for-CVE-2018-20330-and-19664.patch', LIBJPEG_TURBO_PATH),
     ('0013-Remove-unused-gni-for-av1-build.patch', THIRD_PARTY_PATH),

--- a/talk/owt/patches/0008-Disable-loop-range-analysis-when-build-with-Xcode-cl.patch
+++ b/talk/owt/patches/0008-Disable-loop-range-analysis-when-build-with-Xcode-cl.patch
@@ -1,0 +1,31 @@
+From e662812f4dd3d5295aa1b418415833d12af94230 Mon Sep 17 00:00:00 2001
+From: Jianjun Zhu <jianjun.zhu@intel.com>
+Date: Tue, 22 Sep 2020 17:21:59 +0800
+Subject: [PATCH] Disable loop range analysis when build with Xcode clang.
+
+Range loop analysis is disabled by default in clang 12, but it's enabled by
+clang shipped with Xcode 12. Disable it before warnings in WebRTC are fixed.
+---
+ config/compiler/BUILD.gn | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
+index 298da6368..575c7ee56 100644
+--- a/config/compiler/BUILD.gn
++++ b/config/compiler/BUILD.gn
+@@ -1409,6 +1409,12 @@ config("default_warnings") {
+       cflags += [ "-Wundeclared-selector" ]
+     }
+ 
++    if (use_xcode_clang) {
++      # Range loop analysis is disabled by default in clang 12. But it's enabled
++      # by clang shipped with Xcode 12.
++      cflags += [ "-Wno-range-loop-analysis" ]
++    }
++
+     # Suppress warnings about ABI changes on ARM (Clang doesn't give this
+     # warning).
+     if (current_cpu == "arm" && !is_clang) {
+-- 
+2.26.2
+


### PR DESCRIPTION
Range loop analysis is disabled by default in clang 12, but it's enabled by clang shipped with Xcode 12. Disable it before warnings in WebRTC are fixed.