### PR TITLE
Enable webtransport for native client

### DIFF
--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -70,6 +70,11 @@ declare_args() {
   # Includes tests.
   owt_include_tests = false
 
+  # Include quic support
+  owt_use_quic = false
+  owt_quic_header_root = ""
+  owt_quic_lib_root = ""
+
   # Some non-Chromium builds don't support building java targets.
   enable_java_templates = true
 }

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -171,6 +171,14 @@ static_library("owt_sdk_base") {
   } else {
     defines += [ "OWT_USE_H265" ]
   }
+  
+  if (owt_use_quic) {
+    defines += [ "OWT_ENABLE_QUIC" ]
+    if (owt_quic_header_root != "") {
+      include_dirs += [ owt_quic_header_root ]
+    }
+  }
+  
   if (is_win || is_linux) {
     # Custom audio/video input and output.
     # When rebasing libwebrtc to a new version, custom audio/video input/output
@@ -312,6 +320,17 @@ static_library("owt_sdk_conf") {
   ]
   if (is_clang) {
     configs -= [ "//build/config/clang:find_bad_constructs" ]
+  }
+
+  if (owt_use_quic) {
+    defines = [ "OWT_ENABLE_QUIC" ]
+    if (owt_quic_header_root != "") {
+      sources += [
+        "sdk/conference/conferencewebtransportchannel.cc",
+        "sdk/conference/conferencewebtransportchannel.h",
+      ]
+      include_dirs += [ owt_quic_header_root ]
+    }
   }
 }
 if (is_ios) {

--- a/talk/owt/include/sio_message.h
+++ b/talk/owt/include/sio_message.h
@@ -5,6 +5,7 @@
 //
 #ifndef __SIO_MESSAGE_H__
 #define __SIO_MESSAGE_H__
+
 #include <string>
 #include <memory>
 #include <vector>
@@ -14,6 +15,8 @@
 namespace sio
 {
     using namespace std;
+    using std::string;
+    using std::vector;
     
     class message
     {

--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -21,9 +21,5 @@ AudioProcessingSettings GlobalConfiguration::audio_processing_settings_ = {
 AudioProcessingSettings GlobalConfiguration::audio_processing_settings_ = {
     true, true, true, true};
 #endif
-#ifdef OWT_ENABLE_QUIC
-std::vector<cert_fingerprint_t>
-    GlobalConfiguration::trusted_quic_certificate_fingerprints_;
-#endif
 }
 }

--- a/talk/owt/sdk/base/globalconfiguration.cc
+++ b/talk/owt/sdk/base/globalconfiguration.cc
@@ -21,5 +21,9 @@ AudioProcessingSettings GlobalConfiguration::audio_processing_settings_ = {
 AudioProcessingSettings GlobalConfiguration::audio_processing_settings_ = {
     true, true, true, true};
 #endif
+#ifdef OWT_ENABLE_QUIC
+std::vector<cert_fingerprint_t>
+    GlobalConfiguration::trusted_quic_certificate_fingerprints_;
+#endif
 }
 }

--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -28,7 +28,6 @@ bool PeerConnectionChannel::InitializePeerConnection() {
   audio_transceiver_direction_ = webrtc::RtpTransceiverDirection::kSendRecv;
   video_transceiver_direction_ = webrtc::RtpTransceiverDirection::kSendRecv;
   configuration_.enable_dtls_srtp = true;
-  configuration_.crypto_options->srtp.enable_gcm_crypto_suites = true;
   configuration_.sdp_semantics = webrtc::SdpSemantics::kUnifiedPlan;
   peer_connection_ =
       (factory_->CreatePeerConnection(configuration_, this)).get();

--- a/talk/owt/sdk/base/peerconnectionchannel.cc
+++ b/talk/owt/sdk/base/peerconnectionchannel.cc
@@ -28,6 +28,7 @@ bool PeerConnectionChannel::InitializePeerConnection() {
   audio_transceiver_direction_ = webrtc::RtpTransceiverDirection::kSendRecv;
   video_transceiver_direction_ = webrtc::RtpTransceiverDirection::kSendRecv;
   configuration_.enable_dtls_srtp = true;
+  configuration_.crypto_options->srtp.enable_gcm_crypto_suites = true;
   configuration_.sdp_semantics = webrtc::SdpSemantics::kUnifiedPlan;
   peer_connection_ =
       (factory_->CreatePeerConnection(configuration_, this)).get();

--- a/talk/owt/sdk/base/stream.cc
+++ b/talk/owt/sdk/base/stream.cc
@@ -721,9 +721,6 @@ MediaStreamInterface* RemoteStream::MediaStream() {
 QuicStream::QuicStream(owt::quic::QuicTransportStreamInterface* quic_stream,
            const std::string& session_id)
     : quic_stream_(quic_stream), session_id_(session_id) {
-  if (quic_stream_) {
-    quic_stream_->SetVisitor(this);
-  }
 }
 
 QuicStream::~QuicStream() {
@@ -734,13 +731,14 @@ QuicStream::~QuicStream() {
 }
 
 void QuicStream::Write(uint8_t* data, size_t length) {
-  if (quic_stream_ && can_write_ && !fin_read_) {
-    quic_stream_->Write(data, length);
+  if (quic_stream_ /*&& can_write_*/ && !fin_read_) {
+    size_t written = quic_stream_->Write(data, length);
+    RTC_LOG(LS_ERROR) << "Bytes written:" << written;
   }
 }
 
 size_t QuicStream::Read(uint8_t* data, size_t length) {
-  if (quic_stream_ && data && length > 0 && can_read_ && !fin_read_) {
+  if (quic_stream_ && data && length > 0 /*&& can_read_*/ && !fin_read_) {
     return quic_stream_->Read(data, length);
   } else {
     return 0;
@@ -748,7 +746,7 @@ size_t QuicStream::Read(uint8_t* data, size_t length) {
 }
 
 size_t QuicStream::ReadableBytes() const {
-  if (quic_stream_ && can_read_ && !fin_read_) {
+  if (quic_stream_ /*&& can_read_*/ && !fin_read_) {
     return quic_stream_->ReadableBytes();
   } else {
     return 0;

--- a/talk/owt/sdk/base/stream.cc
+++ b/talk/owt/sdk/base/stream.cc
@@ -439,6 +439,21 @@ std::shared_ptr<LocalStream> LocalStream::Create(
 }
 #endif
 
+#ifdef OWT_ENABLE_QUIC
+LocalStream::LocalStream(std::shared_ptr<WritableStream> writer) {
+  writer_ = writer;
+  is_data_ = true;
+}
+
+std::shared_ptr<LocalStream> LocalStream::Create(
+    std::shared_ptr<WritableStream> writable_stream,
+    int& error_code) {
+  std::shared_ptr<LocalStream> stream(new LocalStream(writable_stream));
+  error_code = 0;
+  return stream;
+}
+#endif
+
 LocalStream::LocalStream(const LocalCameraStreamParameters& parameters,
                          int& error_code) {
   if (!parameters.AudioEnabled() && !parameters.VideoEnabled()) {
@@ -654,6 +669,7 @@ LocalStream::LocalStream(
   media_stream_->AddRef();
 }
 #endif
+
 RemoteStream::RemoteStream(MediaStreamInterface* media_stream,
                            const std::string& from)
     : origin_(from) {
@@ -662,6 +678,7 @@ RemoteStream::RemoteStream(MediaStreamInterface* media_stream,
   media_stream_ = media_stream;
   media_stream_->AddRef();
 }
+
 RemoteStream::RemoteStream(
     const std::string& id,
     const std::string& from,
@@ -671,14 +688,25 @@ RemoteStream::RemoteStream(
       origin_(from),
       subscription_capabilities_(subscription_capabilities),
       publication_settings_(publication_settings) {}
-std::string RemoteStream::Origin() {
+  std::string RemoteStream::Origin() {
   return origin_;
 }
+
 void RemoteStream::MediaStream(MediaStreamInterface* media_stream) {
   Stream::MediaStream(media_stream);
 }
 MediaStreamInterface* RemoteStream::MediaStream() {
   return media_stream_;
 }
+
+#ifdef OWT_ENABLE_QUIC
+RemoteStream::RemoteStream(
+    std::shared_ptr<ReadableStream> reader,
+    const std::string& from)
+    : origin_(from) {
+  reader_ = reader;
+  is_data_ = true;
+}
+#endif
 }  // namespace base
 }  // namespace owt

--- a/talk/owt/sdk/base/stream.cc
+++ b/talk/owt/sdk/base/stream.cc
@@ -452,8 +452,8 @@ std::shared_ptr<LocalStream> LocalStream::Create(
 #endif
 
 #ifdef OWT_ENABLE_QUIC
-LocalStream::LocalStream(std::shared_ptr<QuicStream> writer) {
-  quic_stream_ = writer;
+LocalStream::LocalStream(std::shared_ptr<QuicStream> quic_stream) {
+  quic_stream_ = quic_stream;
   has_data_ = true;
 }
 

--- a/talk/owt/sdk/conference/conferenceclient.cc
+++ b/talk/owt/sdk/conference/conferenceclient.cc
@@ -167,7 +167,7 @@ enum ConferenceClient::StreamType : int {
   kStreamTypeCamera = 1,
   kStreamTypeScreen,
   kStreamTypeMix,
-  kStreamTypeQuic,
+  kStreamTypeData,
 };
 const std::string play_pause_failure_message =
     "Cannot play/pause a stream that have not been published or subscribed.";
@@ -333,7 +333,8 @@ void ConferenceClient::InitializeQuicClientIfSupported(const std::string& token_
 
   if (webtransport_url.length() > 0) {
     web_transport_channel_ = std::make_shared<ConferenceWebTransportChannel>(
-        webtransport_url, webtransport_id_, webtransport_token_, signaling_channel_, event_queue_);
+        configuration_, webtransport_url, webtransport_id_,
+        webtransport_token_, signaling_channel_, event_queue_);
     web_transport_channel_->AddObserver(this);
     web_transport_channel_->Connect();
   }
@@ -482,7 +483,7 @@ void ConferenceClient::Join(
       on_failure);
 }
 
-
+#ifdef OWT_ENABLE_QUIC
 static  void ConvertUUID(const char* src_ptr, uint8_t* dest) {
 #define GUID_CHAR_LEN 32
 #define GUID_BIN_LEN 16
@@ -508,6 +509,7 @@ static  void ConvertUUID(const char* src_ptr, uint8_t* dest) {
   }
   delete []src;
 }
+#endif
 
 void ConferenceClient::Publish(
     std::shared_ptr<LocalStream> stream,
@@ -1591,7 +1593,7 @@ void ConferenceClient::ParseStreamInfo(sio::message::ptr stream_info,
       remote_stream->has_video_ = false;
       remote_stream->has_data_ = true;
       added_streams_[id] = remote_stream;
-      added_stream_type_[id] = StreamType::kStreamTypeQuic;
+      added_stream_type_[id] = StreamType::kStreamTypeData;
       {
         const std::lock_guard<std::mutex> lock(stream_update_observer_mutex_);
         current_conference_info_->AddOrUpdateStream(remote_stream, updated);

--- a/talk/owt/sdk/conference/conferenceclient.cc
+++ b/talk/owt/sdk/conference/conferenceclient.cc
@@ -162,10 +162,12 @@ void ConferenceInfo::TriggerOnStreamMuteOrUnmute(
     }
   }
 }
+
 enum ConferenceClient::StreamType : int {
   kStreamTypeCamera = 1,
   kStreamTypeScreen,
   kStreamTypeMix,
+  kStreamTypeQuic,
 };
 const std::string play_pause_failure_message =
     "Cannot play/pause a stream that have not been published or subscribed.";
@@ -186,8 +188,7 @@ ConferenceClient::ConferenceClient(
   signaling_channel_->AddObserver(*this);
 #ifdef OWT_ENABLE_QUIC
   // Quic transport client will be created when we join the meeting.
-
-  quic_client_connected_ = false;
+  web_transport_channel_connected_ = false;
 #endif
 }
 
@@ -246,17 +247,52 @@ void ConferenceClient::RemoveStreamUpdateObserver(
 #ifdef OWT_ENABLE_QUIC
 void ConferenceClient::OnConnected() {
   RTC_LOG(LS_INFO) << "Quic client connected.";
-  quic_client_connected_ = true;
+  web_transport_channel_connected_ = true;
 }
 
 void ConferenceClient::OnConnectionFailed() {
   RTC_LOG(LS_INFO) << "Quic client disconnected.";
-  quic_client_connected_ = false;
+  web_transport_channel_connected_ = false;
 }
 
-void ConferenceClient::OnIncomingStream(
-    owt::quic::QuicTransportStreamInterface*) {
-  RTC_LOG(LS_INFO) << "Incoming quic stream.";
+void ConferenceClient::OnIncomingStream(const std::string& session_id,
+  owt::quic::QuicTransportStreamInterface* stream) {
+  RTC_LOG(LS_INFO) << "Quic client received a stream on session:" << session_id;
+  TriggerOnIncomingStream(session_id, stream);
+}
+
+std::string ConferenceClient::WebTransportId() {
+  return webtransport_id_;
+}
+
+// Get transportId from the base64 encoded webTransportToken
+bool ConferenceClient::ParseWebTransportToken() {
+  if (webtransport_token_ == "" ||
+      !StringUtils::IsBase64EncodedString(webtransport_token_)) {
+    RTC_LOG(LS_ERROR) << "Invalid WebTransport token received from server.";
+    return false;
+  }
+
+  std::string base64_decoded("");
+  if (!rtc::Base64::Decode(webtransport_token_, rtc::Base64::DO_STRICT,
+                           &base64_decoded, nullptr)) {
+    RTC_LOG(LS_ERROR) << "Failed to decode token for webTransportId";
+    return false;
+  }
+  Json::Value json_token;
+  Json::Reader reader;
+  if (!reader.parse(base64_decoded, json_token)) {
+    RTC_LOG(LS_ERROR) << "Parsing token body failed.";
+    return false;
+  }
+  bool res = rtc::GetStringFromJsonObject(json_token, "transportId",
+                                          &webtransport_id_);
+  if (!res) {
+    RTC_LOG(LS_ERROR) << "Failed to get transportId from webTransportToken";
+    return false;
+  }
+
+  return res;
 }
 
 void ConferenceClient::InitializeQuicClientIfSupported(const std::string& token_base64) {
@@ -281,51 +317,26 @@ void ConferenceClient::InitializeQuicClientIfSupported(const std::string& token_
   std::string webtransport_url("");
   bool res = rtc::GetStringFromJsonObject(json_token, "webTransportUrl", &webtransport_url);
   if (!res) {
-    RTC_LOG(LS_INFO) << "Server does not support WebTransport";
+    RTC_LOG(LS_INFO) << "Server does not support WebTransport or does not provide the URL for QUIC";
     return;
   }
 
-  if (quic_transport_factory_ && webtransport_url.length() > 0) {
-    std::vector<owt::base::cert_fingerprint_t> trusted_fingerprints =
-        GlobalConfiguration::GetTrustedQuicCertificateFingerPrints();
-    size_t cert_fingerprint_size = trusted_fingerprints.size();
-
-    owt::quic::QuicTransportClientInterface::Parameters quic_params;
-    memset(&quic_params, 0, sizeof(quic_params));
-    if (cert_fingerprint_size > 0) {
-      quic_params.server_certificate_fingerprints =
-          new owt::quic::CertificateFingerprint[cert_fingerprint_size];
-      quic_params.server_certificate_fingerprints_length =
-          cert_fingerprint_size;
-    }
-    int fingerprint_idx = 0;
-    for (auto fingerprint : trusted_fingerprints) {
-      quic_params.server_certificate_fingerprints[fingerprint_idx] =
-          new char[QUIC_CERT_FINGERPRINT_SIZE];
-      memcpy(&quic_params.server_certificate_fingerprints[fingerprint_idx],
-             fingerprint.data(), fingerprint.size());
-    }
-
+  if (webtransport_url.length() > 0) {
     web_transport_channel_ = std::make_shared<ConferenceWebTransportChannel>(
-        webtransport_url, signaling_channel_, event_queue_);
+        webtransport_url, webtransport_id_, webtransport_token_, signaling_channel_, event_queue_);
     web_transport_channel_->AddObserver(this);
     web_transport_channel_->Connect();
-
-    for (int i = 0; i < cert_fingerprint_size; i++) {
-      delete [] quic_params.server_certificate_fingerprints[i];
-    }
-    delete[] quic_params.server_certificate_fingerprints;
   }
 }
 
 void ConferenceClient::CreateSendStream(
-    std::function<void(std::shared_ptr<owt::base::WritableStream>)> on_success,
+    std::function<void(std::shared_ptr<owt::base::LocalStream>)> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   if (!on_success) {
     RTC_LOG(LS_WARNING) << "No success callback provided. Do nothing.";
     return;
   }
-  if (!quic_transport_client_.get() || !quic_client_connected_) {
+  if (!web_transport_channel_.get() || !web_transport_channel_connected_) {
     if (on_failure != nullptr) {
       event_queue_->PostTask([on_failure]() {
         std::unique_ptr<Exception> e(
@@ -336,12 +347,8 @@ void ConferenceClient::CreateSendStream(
     }
     return;
   }
-  // Sychronous call for creating the stream.
-  owt::quic::QuicTransportStreamInterface* quic_stream =
-      quic_transport_client_->CreateOutgoingUnidirectionalStream();
-  event_queue_->PostTask([on_success, quic_stream]() {
-    on_success(std::make_shared<owt::base::WritableStream>(quic_stream));
-  }
+
+  web_transport_channel_->CreateSendStream(on_success, on_failure);
 }
 #endif
 
@@ -366,11 +373,7 @@ void ConferenceClient::Join(
                            "please pass it without modification.";
     token_base64 = rtc::Base64::Encode(token);
   }
-#ifdef OWT_ENABLE_QUIC
-// If server provides WebTransport channel, prepare the QUIC client as well. No
-// underlying webtransport connection setup at this phase.
-  InitializeQuicClientIfSupported(token_base64);
-#endif
+
   signaling_channel_->Connect(
       token_base64,
       [=](sio::message::ptr info) {
@@ -443,6 +446,22 @@ void ConferenceClient::Join(
             TriggerOnStreamAdded(*it, true);
           }
         }
+#ifdef OWT_ENABLE_QUIC
+        auto webtransport_token = info->get_map()["webTransportToken"];
+        if (webtransport_token != nullptr &&
+            webtransport_token->get_flag() == sio::message::flag_string) {
+          // Base64 encoded webTransportToken with format:
+          // {tokenId, transportId, participantId, issueTime}. Parse the transportId
+          // and save it.
+          webtransport_token_ =
+              info->get_map()["webTransportToken"]->get_string();
+          bool transport_id_get = ParseWebTransportToken();
+          // If server provides WebTransport channel, prepare the QUIC client as
+          // well. No underlying webtransport connection setup at this phase.
+          if (transport_id_get)
+            InitializeQuicClientIfSupported(token_base64);
+        }
+#endif
         // Invoke the success callback before trigger any participant join or
         // stream added message.
         if (on_success) {
@@ -452,6 +471,7 @@ void ConferenceClient::Join(
       },
       on_failure);
 }
+
 void ConferenceClient::Publish(
     std::shared_ptr<LocalStream> stream,
     std::function<void(std::shared_ptr<ConferencePublication>)> on_success,
@@ -470,22 +490,24 @@ void ConferenceClient::Publish(
   }
 #ifdef OWT_ENABLE_QUIC
   if (stream->DataEnabled()) {
-    if (quic_transport_client_.get() && quic_client_connected_) {
-      // The underlying quic connection is still usable.
-      std::shared_ptr<owt::conference::ConferenceWebTransportChannel> wtc(
-          new owt::conference::ConferenceWebTransportChannel(signaling_channel_,
-                                          event_queue_));
+    if (web_transport_channel_ && web_transport_channel_connected_) {
       std::weak_ptr<ConferenceClient> weak_this = shared_from_this();
-      wtc->Publish(
+      web_transport_channel_->Publish(
           stream,
-          [on_success, weak_this](std::string session_id, std::string transport_id) {
+          [stream, on_success, weak_this](std::string session_id, std::string transport_id) {
             auto that = weak_this.lock();
             if (!that)
               return;
             // map current pcc
             if (on_success != nullptr) {
+              // For QUIC stream we use session_id as stream_id for publication.
               std::shared_ptr<ConferencePublication> cp(
-                  new ConferencePublication(that, session_id, transport_id));
+                  new ConferencePublication(that, session_id, session_id));
+              {
+                std::lock_guard<std::mutex> lock(that->quic_publications_mutex_);
+                that->quic_publications_[session_id] = cp;
+              }
+              stream->Stream()->Write((uint8_t*)session_id.c_str(), session_id.length());
               on_success(cp);
             }
           },
@@ -503,6 +525,7 @@ void ConferenceClient::Publish(
         });
       }
     }
+    return;
   }
 #endif
   if (!CheckNullPointer((uintptr_t)(stream->MediaStream()), on_failure)) {
@@ -572,11 +595,52 @@ void ConferenceClient::Subscribe(
     const SubscribeOptions& options,
     std::function<void(std::shared_ptr<ConferenceSubscription>)> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
-  if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
-    RTC_LOG(LS_ERROR) << "Local stream cannot be nullptr.";
+  if (!CheckSignalingChannelOnline(on_failure)) {
     return;
   }
-  if (!CheckSignalingChannelOnline(on_failure)) {
+#ifdef OWT_ENABLE_QUIC
+  if (stream->DataEnabled()) {
+    if (web_transport_channel_ && web_transport_channel_connected_) {
+      std::weak_ptr<ConferenceClient> weak_this = shared_from_this();
+      web_transport_channel_->Subscribe(
+          stream,
+          [on_success, weak_this](std::string session_id) {
+            auto that = weak_this.lock();
+            if (!that)
+              return;
+            // map current pcc
+            if (on_success != nullptr) {
+              // For QUIC stream we use session_id as stream_id for publication.
+              std::shared_ptr<ConferenceSubscription> cp(
+                  new ConferenceSubscription(that, session_id, session_id));
+              {
+                std::lock_guard<std::mutex> lock(
+                    that->quic_subscriptions_mutex_);
+                that->quic_subscriptions_[session_id] = cp;
+              }
+              on_success(cp);
+            }
+          },
+          on_failure);
+    } else {
+      RTC_LOG(LS_ERROR)
+          << "Cannot subscribe a quic stream without quic client connected.";
+      std::string failure_message(
+          "Subscribing quic stream without quic client connected");
+      if (on_failure != nullptr) {
+        event_queue_->PostTask([on_failure, failure_message]() {
+          std::unique_ptr<Exception> e(new Exception(
+              ExceptionType::kConferenceUnknown, failure_message));
+          on_failure(std::move(e));
+        });
+      }
+    }
+    return;
+  }
+#endif
+
+  if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
+    RTC_LOG(LS_ERROR) << "Remote stream cannot be nullptr.";
     return;
   }
   RTC_LOG(LS_INFO) << "Stream ID: " << stream->Id();
@@ -670,6 +734,18 @@ void ConferenceClient::UnPublish(
   if (!CheckSignalingChannelOnline(on_failure)) {
     return;
   }
+#ifdef OWT_ENABLE_QUIC
+  {
+    // Unpublish on quic connection if it is a quic session.
+    std::lock_guard<std::mutex> lock(quic_publications_mutex_);
+    auto it = quic_publications_.find(session_id);
+    if (it != quic_publications_.end() && web_transport_channel_) {
+      web_transport_channel_->Unpublish(session_id, on_success, on_failure);
+      quic_publications_.erase(session_id);
+      return;
+    }
+  }
+#endif
   auto pcc = GetConferencePeerConnectionChannel(session_id);
   if (pcc == nullptr) {
     if (on_failure) {
@@ -706,6 +782,18 @@ void ConferenceClient::UnSubscribe(
   if (!CheckSignalingChannelOnline(on_failure)) {
     return;
   }
+#ifdef OWT_ENABLE_QUIC
+  {
+    // Unsubscribe on quic connection if it is a quic session.
+    std::lock_guard<std::mutex> lock(quic_subscriptions_mutex_);
+    auto it = quic_subscriptions_.find(session_id);
+    if (it != quic_subscriptions_.end() && web_transport_channel_) {
+      web_transport_channel_->Unsubscribe(session_id, on_success, on_failure);
+      quic_subscriptions_.erase(session_id);
+      return;
+    }
+  }
+#endif
   auto pcc = GetConferencePeerConnectionChannel(session_id);
   if (pcc == nullptr) {
     if (on_failure) {
@@ -899,11 +987,27 @@ void ConferenceClient::Leave(
     std::lock_guard<std::mutex> lock(subscribe_pcs_mutex_);
     subscribe_pcs_.clear();
   }
+#ifdef OWT_ENABLE_QUIC
+  {
+    std::lock_guard<std::mutex> lock(quic_publications_mutex_);
+    for (auto& publication : quic_publications_) {
+      publication.second->Stop();
+    }
+    quic_publications_.clear();
+  }
+  {
+    std::lock_guard<std::mutex> lock(quic_subscriptions_mutex_);
+    for (auto& subscription : quic_subscriptions_) {
+      subscription.second->Stop();
+    }
+    quic_subscriptions_.clear();
+  }
+#endif
   signaling_channel_->Disconnect(RunInEventQueue(on_success), on_failure);
 }
 void ConferenceClient::GetConnectionStats(
     const std::string& session_id,
-    std::function<void(std::shared_ptr<ConnectionStats>)> on_success,
+    std::function<void(std::shared_ptr<owt::base::ConnectionStats>)> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   auto pcc = GetConferencePeerConnectionChannel(session_id);
   if (pcc == nullptr) {
@@ -976,8 +1080,11 @@ void ConferenceClient::OnCustomMessage(std::string& from,
   }
 }
 void ConferenceClient::OnSignalingMessage(sio::message::ptr message) {
-  // v1.2 signaling protocol replaces this with 
+  // v1.2 may return SessionProgress which is  {id: SessionId, status: "ready|error"}.
   std::string transport_id = message->get_map()["id"]->get_string();
+  std::string stream_id = (message->get_map()["peerId"] == nullptr)
+                              ? message->get_map()["id"]->get_string()
+                              : message->get_map()["peerId"]->get_string();
   // Check the status before delivering to pcc.
   auto soac_status = message->get_map()["status"];
   if (soac_status == nullptr ||
@@ -989,9 +1096,7 @@ void ConferenceClient::OnSignalingMessage(sio::message::ptr message) {
     RTC_LOG(LS_WARNING) << "Ignore signaling status except soac/ready/error.";
     return;
   }
-  // With webtransport enabled, we will need to first look at the webtransport channel first.
-#ifdef OWT_ENABLE_QUIC
-#endif
+  // On Signaling messae will only be invoked for WebRTC channels.
   auto pcc = GetConferencePeerConnectionChannel(stream_id);
   if (pcc == nullptr) {
     RTC_LOG(LS_WARNING) << "Received signaling message from unknown sender.";
@@ -1123,15 +1228,24 @@ void ConferenceClient::ParseStreamInfo(sio::message::ptr stream_info,
   std::string owner_id("");
   std::string video_source("");
   std::string audio_source("");
-  bool has_audio = false, has_video = false;
+  std::string data_source("");
+  bool has_audio = false, has_video = false, has_data = false;
   std::unordered_map<std::string, std::string> attributes;
   auto media_info = stream_info->get_map()["media"];
   if (media_info == nullptr ||
       media_info->get_flag() != sio::message::flag_object) {
-    RTC_DCHECK(false);
-    RTC_LOG(LS_ERROR) << "Invalid media info from stream " << id
-                      << ", this stream will be ignored.";
-    return;
+    // Check if current stream is a quic stream.
+    auto data_info = stream_info->get_map()["data"];
+    if (data_info != nullptr &&
+        data_info->get_flag() == sio::message::flag_boolean) {
+      has_data = data_info->get_bool();
+    }
+    // A stream must either has data or media.
+    if (!has_data) {
+      RTC_LOG(LS_ERROR) << "Invalid media info from stream " << id
+                        << ", this stream will be ignored.";
+      return;
+    }
   }
   auto type = stream_info->get_map()["type"]->get_string();
   if (type != "mixed" && type != "forward") {
@@ -1149,7 +1263,8 @@ void ConferenceClient::ParseStreamInfo(sio::message::ptr stream_info,
       }
     }
   } else if (type == "forward") {
-    // Get the stream attributes and owner id;
+    // Get the stream attributes and owner id; QUIC streams will
+    // always be of "foward" type.
     auto pub_info = stream_info->get_map()["info"];
     if (pub_info == nullptr ||
         pub_info->get_flag() != sio::message::flag_object) {
@@ -1160,6 +1275,7 @@ void ConferenceClient::ParseStreamInfo(sio::message::ptr stream_info,
     owner_id = pub_info->get_map()["owner"]->get_string();
     attributes = AttributesFromStreamInfo(pub_info);
   }
+
   SubscriptionCapabilities subscription_capabilities;
   PublicationSettings publication_settings;
   auto audio_info = media_info->get_map()["audio"];
@@ -1404,6 +1520,15 @@ void ConferenceClient::ParseStreamInfo(sio::message::ptr stream_info,
   // SubscriptionCapabilities have been gathered, we construct remote streams.
   bool updated = false;
   if (type == "forward") {
+    // Forward stream might be quic stream
+    if (has_data) {
+      auto remote_stream = std::make_shared<RemoteStream>(id, owner_id);
+      remote_stream->has_audio_ = false;
+      remote_stream->has_video_ = false;
+      remote_stream->has_data_ = true;
+      added_streams_[id] = remote_stream;
+      added_stream_type_[id] = StreamType::kStreamTypeQuic;
+    }
     AudioSourceInfo audio_source_info(AudioSourceInfo::kUnknown);
     VideoSourceInfo video_source_info(VideoSourceInfo::kUnknown);
     auto audio_source_it = audio_source_names.find(audio_source);
@@ -1512,6 +1637,19 @@ void ConferenceClient::TriggerOnUserLeft(sio::message::ptr user_info) {
   current_conference_info_->TriggerOnParticipantLeft(user_id);
   current_conference_info_->RemoveParticipantById(user_id);
 }
+
+#ifdef OWT_ENABLE_QUIC
+void ConferenceClient::TriggerOnIncomingStream(
+    const std::string& session_id,
+                             owt::quic::QuicTransportStreamInterface* stream) {
+  const std::lock_guard<std::mutex> lock(stream_update_observer_mutex_);
+  for (auto its = stream_update_observers_.begin();
+       its != stream_update_observers_.end(); ++its) {
+    (*its).get().OnIncomingStream(session_id, stream);
+  }
+}
+#endif
+
 bool ConferenceClient::ParseUser(sio::message::ptr user_message,
                                  Participant** participant) const {
   if (user_message == nullptr ||

--- a/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
+++ b/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
@@ -638,7 +638,7 @@ void ConferencePeerConnectionChannel::Subscribe(
   }
   signaling_channel_->SendInitializationMessage(
       sio_options, "", stream->Id(),
-      [this](std::string session_id) {
+      [this](std::string session_id, std::string transport_id) {
         // Pre-set the session's ID.
         SetSessionId(session_id);
         CreateOffer();

--- a/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
+++ b/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
@@ -920,7 +920,7 @@ void ConferencePeerConnectionChannel::SendPublishMessage(
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   signaling_channel_->SendInitializationMessage(
       options, stream->MediaStream()->id(), "",
-      [stream, this](std::string session_id) {
+      [stream, this](std::string session_id, std::string transport_id) {
         SetSessionId(session_id);
         for (const auto& track : stream->MediaStream()->GetAudioTracks()) {
           webrtc::RtpTransceiverInit transceiver_init;

--- a/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
+++ b/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
@@ -404,6 +404,20 @@ void ConferencePeerConnectionChannel::Publish(
     }
     return;
   }
+  int audio_track_count = 0, video_track_count = 0;
+  audio_track_count = stream->MediaStream()->GetAudioTracks().size();
+  video_track_count = stream->MediaStream()->GetVideoTracks().size();
+  if (audio_track_count == 0 && video_track_count == 0) {
+    if (on_failure != nullptr) {
+      event_queue_->PostTask([on_failure]() {
+        std::unique_ptr<Exception> e(new Exception(
+            ExceptionType::kConferenceUnknown,
+            "Cannot publish media stream without any tracks."));
+        on_failure(std::move(e));
+      });
+    }
+    return;
+  }
   publish_success_callback_ = on_success;
   failure_callback_ = on_failure;
   audio_transceiver_direction_=webrtc::RtpTransceiverDirection::kSendOnly;
@@ -416,24 +430,32 @@ void ConferencePeerConnectionChannel::Publish(
         sio::string_message::create(attr.second);
   }
   options->get_map()[kStreamOptionAttributesKey] = attributes_ptr;
-  // media
+  // TODO(jianlin): currently we fix mid to 0/1. Need
+  // to update the flow to set local desc for retrieving the mid.
   sio::message::ptr media_ptr = sio::object_message::create();
-  if (stream->MediaStream()->GetAudioTracks().size() == 0) {
-    media_ptr->get_map()["audio"] = sio::bool_message::create(false);
-  } else {
+  sio::message::ptr tracks_ptr = sio::array_message::create();
+  if (audio_track_count != 0) {
+    RTC_LOG(LS_INFO) << "Adding audio tracks for publish.";
     sio::message::ptr audio_options = sio::object_message::create();
+    audio_options->get_map()["type"] = sio::string_message::create("audio");
+    audio_options->get_map()["mid"] = sio::string_message::create("0");
     if (stream->Source().audio == owt::base::AudioSourceInfo::kScreenCast) {
       audio_options->get_map()["source"] =
           sio::string_message::create("screen-cast");
     } else {
       audio_options->get_map()["source"] = sio::string_message::create("mic");
     }
-    media_ptr->get_map()["audio"] = audio_options;
+    tracks_ptr->get_vector().push_back(audio_options);
   }
-  if (stream->MediaStream()->GetVideoTracks().size() == 0) {
-    media_ptr->get_map()["video"] = sio::bool_message::create(false);
-  } else {
+  if (video_track_count != 0) {
+    RTC_LOG(LS_INFO) << "Adding video tracks for publish.";
     sio::message::ptr video_options = sio::object_message::create();
+    video_options->get_map()["type"] = sio::string_message::create("video");
+    if (audio_track_count == 0) {
+      video_options->get_map()["mid"] = sio::string_message::create("0");
+    } else {
+      video_options->get_map()["mid"] = sio::string_message::create("1");
+    }
     if (stream->Source().video == owt::base::VideoSourceInfo::kScreenCast) {
       video_options->get_map()["source"] =
           sio::string_message::create("screen-cast");
@@ -441,11 +463,16 @@ void ConferencePeerConnectionChannel::Publish(
       video_options->get_map()["source"] =
           sio::string_message::create("camera");
     }
-    media_ptr->get_map()["video"] = video_options;
+    tracks_ptr->get_vector().push_back(video_options);
   }
+  media_ptr->get_map()["tracks"] = tracks_ptr;
   options->get_map()["media"] = media_ptr;
+  sio::message::ptr transport_ptr = sio::object_message::create();
+  transport_ptr->get_map()["type"] = sio::string_message::create("webrtc");
+  options->get_map()["transport"] = transport_ptr;
   SendPublishMessage(options, stream, on_failure);
 }
+
 static bool SubOptionAllowed(
     const SubscribeOptions& subscribe_options,
     const PublicationSettings& publication_settings,
@@ -556,7 +583,6 @@ void ConferencePeerConnectionChannel::Subscribe(
     }
     return;
   }
-  subscribed_stream_ = stream;
   if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
     RTC_LOG(LS_ERROR) << "Remote stream cannot be nullptr.";
     return;
@@ -572,18 +598,38 @@ void ConferencePeerConnectionChannel::Subscribe(
   }
   subscribe_success_callback_ = on_success;
   failure_callback_ = on_failure;
-  sio::message::ptr sio_options = sio::object_message::create();
-  sio::message::ptr media_options = sio::object_message::create();
+  int audio_track_count = 0, video_track_count = 0;
   if (stream->has_audio_ && !subscribe_options.audio.disabled) {
-    sio::message::ptr audio_options = sio::object_message::create();
-    audio_options->get_map()["from"] =
-        sio::string_message::create(stream->Id());
-    media_options->get_map()["audio"] = audio_options;
-  } else {
-    media_options->get_map()["audio"] = sio::bool_message::create(false);
+    webrtc::RtpTransceiverInit transceiver_init;
+    transceiver_init.direction = webrtc::RtpTransceiverDirection::kRecvOnly;
+    AddTransceiver(cricket::MediaType::MEDIA_TYPE_AUDIO, transceiver_init);
+    audio_track_count = 1;
   }
   if (stream->has_video_ && !subscribe_options.video.disabled) {
+    webrtc::RtpTransceiverInit transceiver_init;
+    transceiver_init.direction = webrtc::RtpTransceiverDirection::kRecvOnly;
+    AddTransceiver(cricket::MediaType::MEDIA_TYPE_VIDEO, transceiver_init);
+    video_track_count = 1;
+  }
+  sio::message::ptr sio_options = sio::object_message::create();
+  sio::message::ptr media_options = sio::object_message::create();
+  sio::message::ptr tracks_options = sio::array_message::create();
+  if (audio_track_count > 0) {
+    sio::message::ptr audio_options = sio::object_message::create();
+    audio_options->get_map()["type"] = sio::string_message::create("audio");
+    audio_options->get_map()["mid"] = sio::string_message::create("0");
+    audio_options->get_map()["from"] =
+        sio::string_message::create(stream->Id());
+    tracks_options->get_vector().push_back(audio_options);
+  }
+  if (video_track_count > 0) {
     sio::message::ptr video_options = sio::object_message::create();
+    video_options->get_map()["type"] = sio::string_message::create("video");
+    if (audio_track_count == 0) {
+      video_options->get_map()["mid"] = sio::string_message::create("0");
+    } else {
+      video_options->get_map()["mid"] = sio::string_message::create("1");
+    }
     video_options->get_map()["from"] =
         sio::string_message::create(stream->Id());
     sio::message::ptr video_spec = sio::object_message::create();
@@ -621,21 +667,15 @@ void ConferencePeerConnectionChannel::Subscribe(
       video_options->get_map()["simulcastRid"] =
           sio::string_message::create(subscribe_options.video.rid);
     }
-    media_options->get_map()["video"] = video_options;
-  } else {
-    media_options->get_map()["video"] = sio::bool_message::create(false);
+    tracks_options->get_vector().push_back(video_options);
   }
+
+  media_options->get_map()["tracks"] = tracks_options;
   sio_options->get_map()["media"] = media_options;
-  if (stream->has_audio_ && !subscribe_options.audio.disabled) {
-    webrtc::RtpTransceiverInit transceiver_init;
-    transceiver_init.direction = webrtc::RtpTransceiverDirection::kRecvOnly;
-    AddTransceiver(cricket::MediaType::MEDIA_TYPE_AUDIO, transceiver_init);
-  }
-  if (stream->has_video_ && !subscribe_options.video.disabled) {
-    webrtc::RtpTransceiverInit transceiver_init;
-    transceiver_init.direction = webrtc::RtpTransceiverDirection::kRecvOnly;
-    AddTransceiver(cricket::MediaType::MEDIA_TYPE_VIDEO, transceiver_init);
-  }
+  sio::message::ptr transport_ptr = sio::object_message::create();
+  transport_ptr->get_map()["type"] = sio::string_message::create("webrtc");
+  sio_options->get_map()["transport"] = transport_ptr;
+
   signaling_channel_->SendInitializationMessage(
       sio_options, "", stream->Id(),
       [this](std::string session_id, std::string transport_id) {
@@ -644,6 +684,7 @@ void ConferencePeerConnectionChannel::Subscribe(
         CreateOffer();
       },
       on_failure);  // TODO: on_failure
+  subscribed_stream_ = stream;
 }
 void ConferencePeerConnectionChannel::Unpublish(
     const std::string& session_id,

--- a/talk/owt/sdk/conference/conferencesocketsignalingchannel.cc
+++ b/talk/owt/sdk/conference/conferencesocketsignalingchannel.cc
@@ -20,7 +20,7 @@
 using namespace rtc;
 namespace owt {
 namespace conference {
-#define SIGNALING_PROTOCOL_VERSION "1.1"
+#define SIGNALING_PROTOCOL_VERSION "1.2"
 const std::string kEventNameCustomMessage = "customMessage";
 const std::string kEventNameSignalingMessagePrelude = "signaling";
 const std::string kEventNameSignalingMessage = "soac"; //only for soac message
@@ -486,6 +486,7 @@ void ConferenceSocketSignalingChannel::SendInitializationMessage(
            }
            // TODO: Spec returns {transportId, publication/subscriptionId} while MCU impl
            // is currently returning id and transportId.
+           RTC_LOG(LS_ERROR) << "Fetching transport ID:";
            std::string session_id = msg.at(1)->get_map()["id"]->get_string();
            std::string transport_id("");
            auto transport_id_obj = msg.at(1)->get_map()["transportId"];
@@ -493,6 +494,8 @@ void ConferenceSocketSignalingChannel::SendInitializationMessage(
                transport_id_obj->get_flag() == sio::message::flag_string) {
              transport_id = transport_id_obj->get_string();
            }
+           RTC_LOG(LS_ERROR) << "Session ID:" << session_id
+                             << ", TransportID:" << transport_id;
            if (event_name == kEventNamePublish || event_name == kEventNameSubscribe) {
              on_success(session_id, transport_id);
              return;

--- a/talk/owt/sdk/conference/conferencesocketsignalingchannel.cc
+++ b/talk/owt/sdk/conference/conferencesocketsignalingchannel.cc
@@ -269,8 +269,8 @@ void ConferenceSocketSignalingChannel::Connect(
               socket_client_->close();
               return;
             }
-            // The second element is room info, please refer to MCU
-            // erizoController's implementation for detailed message format.
+            // The second element is room info, please refer to server's
+            // portal implementation for detailed message format.
             sio::message::ptr message = msg.at(1);
             if (message->get_flag() == sio::message::flag_string) {
               OnReconnectionTicket(message->get_string());
@@ -418,7 +418,7 @@ void ConferenceSocketSignalingChannel::OnNotificationFromServer(
       RTC_NOTREACHED();
     }
   } else if (name == kEventNameOnSignalingMessage) {
-    RTC_LOG(LS_VERBOSE) << "Received signaling message from MCU.";
+    RTC_LOG(LS_VERBOSE) << "Received signaling message from server.";
     std::lock_guard<std::mutex> lock(observer_mutex_);
     for (auto it = observers_.begin(); it != observers_.end(); ++it) {
       (*it)->OnSignalingMessage(data);
@@ -484,7 +484,7 @@ void ConferenceSocketSignalingChannel::SendInitializationMessage(
              RTC_DCHECK(false);
              return;
            }
-           // TODO: Spec returns {transportId, publication/subscriptionId} while MCU impl
+           // TODO: Spec returns {transportId, publication/subscriptionId} while server impl
            // is currently returning id and transportId.
            RTC_LOG(LS_ERROR) << "Fetching transport ID:";
            std::string session_id = msg.at(1)->get_map()["id"]->get_string();
@@ -661,7 +661,7 @@ void ConferenceSocketSignalingChannel::OnEmitAck(
       t.detach();
     }
   } else {
-    RTC_LOG(LS_WARNING) << "Send message to MCU received negative ack.";
+    RTC_LOG(LS_WARNING) << "Send message to server received negative ack.";
     if (msg.size() > 1) {
       sio::message::ptr error_ptr = msg.at(1);
       if (error_ptr->get_flag() == sio::message::flag_string) {

--- a/talk/owt/sdk/conference/conferencesocketsignalingchannel.h
+++ b/talk/owt/sdk/conference/conferencesocketsignalingchannel.h
@@ -40,7 +40,7 @@ class ConferenceSocketSignalingChannel
       sio::message::ptr options,
       std::string publish_stream_label,
       std::string subcribe_stream_label,
-      std::function<void(std::string)> on_success,
+      std::function<void(std::string, std::string)> on_success,
       std::function<void(std::unique_ptr<Exception>)> on_failure);
   virtual void SendSdp(
       sio::message::ptr message,

--- a/talk/owt/sdk/conference/conferencesocketsignalingchannel.h
+++ b/talk/owt/sdk/conference/conferencesocketsignalingchannel.h
@@ -139,6 +139,7 @@ class ConferenceSocketSignalingChannel
   std::queue<SioMessage> outgoing_messages_;
   int outgoing_message_id_;
   std::mutex outgoing_message_mutex_;
+  std::string quic_transport_id_;
 };
 }
 }

--- a/talk/owt/sdk/conference/conferencesubscription.cc
+++ b/talk/owt/sdk/conference/conferencesubscription.cc
@@ -216,9 +216,11 @@ void ConferenceSubscription::OnIncomingStream(const std::string& session_id,
   if (ended_ || stream_id_ != session_id)
     return;
   quic_stream_ = std::make_shared<owt::base::QuicStream>(stream, session_id);
+#if 0
   for (auto its = observers_.begin(); its != observers_.end(); ++its) {
     (*its).get().OnReady();
   }
+#endif
 }
 #endif
 

--- a/talk/owt/sdk/conference/conferencesubscription.cc
+++ b/talk/owt/sdk/conference/conferencesubscription.cc
@@ -9,6 +9,7 @@
 #include "talk/owt/sdk/base/stringutils.h"
 #include "talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h"
 #include "talk/owt/sdk/include/cpp/owt/conference/conferencesubscription.h"
+
 using namespace rtc;
 namespace owt {
 namespace conference {
@@ -209,6 +210,18 @@ void ConferenceSubscription::OnStreamError(const std::string& error_msg) {
   }
 }
 
+#ifdef OWT_ENABLE_QUIC
+void ConferenceSubscription::OnIncomingStream(const std::string& session_id,
+    owt::quic::QuicTransportStreamInterface* stream) {
+  if (ended_ || stream_id_ != session_id)
+    return;
+  quic_stream_ = std::make_shared<owt::base::QuicStream>(stream, session_id);
+  for (auto its = observers_.begin(); its != observers_.end(); ++its) {
+    (*its).get().OnReady();
+  }
+}
+#endif
+
 void ConferenceSubscription::AddObserver(SubscriptionObserver& observer) {
   const std::lock_guard<std::mutex> lock(observer_mutex_);
   std::vector<std::reference_wrapper<SubscriptionObserver>>::iterator it =
@@ -233,5 +246,11 @@ void ConferenceSubscription::RemoveObserver(SubscriptionObserver& observer) {
   if (it != observers_.end())
     observers_.erase(it);
 }
+
+#ifdef OWT_ENABLE_QUIC
+std::shared_ptr<owt::base::QuicStream> ConferenceSubscription::Stream() {
+  return quic_stream_;
+}
+#endif
 }
 }

--- a/talk/owt/sdk/conference/conferencewebtransportchannel.cc
+++ b/talk/owt/sdk/conference/conferencewebtransportchannel.cc
@@ -1,0 +1,536 @@
+// Copyright (C) <2018> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "talk/owt/sdk/conference/conferencewebtransportchannel.h"
+#include <future>
+#include <string>
+#include <thread>
+#include <vector>
+#include "talk/owt/sdk/base/functionalobserver.h"
+#include "talk/owt/sdk/base/mediautils.h"
+#include "talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h"
+#include "webrtc/rtc_base/checks.h"
+#include "webrtc/rtc_base/logging.h"
+#include "owt/quic/quic_transport_client_interface.h"
+#include "owt/quic/quic_transport_factory.h"
+#include "owt/quic/quic_transport_stream_interface.h"
+
+using namespace rtc;
+namespace owt {
+namespace conference {
+using std::string;
+
+// Stream option member key
+const std::string kStreamOptionStreamIdKey = "streamId";
+const std::string kStreamOptionStateKey = "state";
+const std::string kStreamOptionDataKey = "type";
+const std::string kStreamOptionWebTransportKey = "data";
+const std::string kStreamOptionScreenKey = "screen";
+const std::string kStreamOptionAttributesKey = "attributes";
+
+ConferenceWebTransportChannel::ConferenceWebTransportChannel(
+    const std::string& url,
+    std::shared_ptr<ConferenceSocketSignalingChannel> signaling_channel,
+    std::shared_ptr<rtc::TaskQueue> event_queue)
+    : signaling_channel_(signaling_channel),
+      session_id_(""),
+      connected_(false),
+      sub_stream_added_(false),
+      sub_server_ready_(false),
+      event_queue_(event_queue),
+      url_(url) {
+  quic_transport_factory_.reset(owt::quic::QuicTransportFactory::Create());
+  quic_client_connected_ = false;
+  RTC_CHECK(signaling_channel_);
+}
+
+ConferenceWebTransportChannel::~ConferenceWebTransportChannel() {
+  RTC_LOG(LS_INFO) << "Deconstruct conference WebTransport channel";
+  if (published_stream_)
+    Unpublish(GetSessionId(), nullptr, nullptr);
+  if (subscribed_stream_)
+    Unsubscribe(GetSessionId(), nullptr, nullptr);
+}
+
+void ConferenceWebTransportChannel::Connect() {
+  std::vector<owt::base::cert_fingerprint_t> trusted_fingerprints =
+      GlobalConfiguration::GetTrustedQuicCertificateFingerPrints();
+  size_t cert_fingerprint_size = trusted_fingerprints.size();
+
+  owt::quic::QuicTransportClientInterface::Parameters quic_params;
+  memset(&quic_params, 0, sizeof(quic_params));
+  if (cert_fingerprint_size > 0) {
+    quic_params.server_certificate_fingerprints =
+        new owt::quic::CertificateFingerprint[cert_fingerprint_size];
+    quic_params.server_certificate_fingerprints_length = cert_fingerprint_size;
+  }
+  int fingerprint_idx = 0;
+  for (auto fingerprint : trusted_fingerprints) {
+    quic_params.server_certificate_fingerprints[fingerprint_idx] =
+        new char[QUIC_CERT_FINGERPRINT_SIZE];
+    memcpy(&quic_params.server_certificate_fingerprints[fingerprint_idx],
+           fingerprint.data(), fingerprint.size());
+  }
+  quic_transport_client = quic_transport_factory_->CreateQuicTransportClient(url_.c_str(), quic_params);
+  if (quic_transport_client_.get()) {
+    quic_transport_client_->SetVistor(this);
+    // Async. Connect status will be notified through visitor.
+    quic_transport_client_->Connect();
+  }
+}
+
+void ConferenceWebTransportChannel::AddObserver(
+    ConferenceWebTransportChannelObserver* observer) {
+  RTC_CHECK(observer);
+  observer_ = observer;
+}
+void ConferenceWebTransportChannel::RemoveObserver(
+    ConferenceWebTransportChannelObserver& observer) {
+  observer_ = nullptr;
+}
+
+bool ConferenceWebTransportChannel::CheckNullPointer(
+    uintptr_t pointer,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  if (pointer)
+    return true;
+  if (on_failure != nullptr) {
+    event_queue_->PostTask([on_failure]() {
+      std::unique_ptr<Exception> e(new Exception(
+          ExceptionType::kConferenceUnknown, "Nullptr is not allowed."));
+      on_failure(std::move(e));
+    });
+  }
+  return false;
+}
+// Failure of publish will be handled here directly; while success needs
+// conference client to construct the ConferencePublication instance,
+// So we're not passing success callback here.
+void ConferenceWebTransportChannel::Publish(
+    std::shared_ptr<LocalStream> stream,
+    std::function<void(std::string, std::string)> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  RTC_LOG(LS_INFO) << "Publish a local stream.";
+  published_stream_ = stream;
+  if ((!CheckNullPointer((uintptr_t)stream.get(), on_failure)) ||
+      (!CheckNullPointer((uintptr_t)stream->QuicStream(), on_failure))) {
+    RTC_LOG(LS_INFO) << "Local stream cannot be nullptr.";
+  }
+  publish_success_callback_ = on_success;
+  failure_callback_ = on_failure;
+  sio::message::ptr options = sio::object_message::create();
+  // attributes
+  sio::message::ptr attributes_ptr = sio::object_message::create();
+  for (auto const& attr : stream->Attributes()) {
+    attributes_ptr->get_map()[attr.first] =
+        sio::string_message::create(attr.second);
+  }
+  options->get_map()[kStreamOptionAttributesKey] = attributes_ptr;
+  // media object should be null for data stream.
+  sio::message::ptr media_ptr = sio::object_message::create();
+  options->get_map()["media"] = media_ptr;
+  options->get_map()["data"] = sio::bool_message::create(true);
+  sio::message::ptr transport_ptr = sio::object_message::create();
+  transport_ptr->get_map()["type"] = sio::string_message::create("quic");
+  transport_ptr->get_map()["id"] = sio::null_message::create();
+  SendPublishMessage(options, stream, on_failure);
+}
+
+// For WebTransport streams we will not check the subscription capabilities,
+// as it does not contain any optional settings.
+static bool SubOptionAllowed(
+    const SubscribeOptions& subscribe_options,
+    const PublicationSettings& publication_settings) {
+  if (subscribe_options.data.enabled && publication_settings.data.enabled)
+    return true;
+  return false;
+}
+void ConferenceWebTransportChannel::Subscribe(
+    std::shared_ptr<RemoteStream> stream,
+    const SubscribeOptions& subscribe_options,
+    std::function<void(std::string)> on_success,
+    std::function<void(std::unique_ptr<owt::base::Exception>)> on_failure) {
+  RTC_LOG(LS_INFO) << "Subscribe a remote stream. It supports data? "
+                   << stream->DataEnabled();
+  if (!SubOptionAllowed(subscribe_options, stream->Settings())) {
+    RTC_LOG(LS_ERROR)
+        << "Subscribe option mismatch with stream subcription capabilities.";
+    if (on_failure != nullptr) {
+      event_queue_->PostTask([on_failure]() {
+        std::unique_ptr<Exception> e(
+            new Exception(ExceptionType::kConferenceUnknown,
+                          "Unsupported subscribe option."));
+        on_failure(std::move(e));
+      });
+    }
+    return;
+  }
+  subscribed_stream_ = stream;
+  if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
+    RTC_LOG(LS_ERROR) << "Remote stream cannot be nullptr.";
+    return;
+  }
+  if (subscribe_success_callback_) {
+    if (on_failure) {
+      event_queue_->PostTask([on_failure]() {
+        std::unique_ptr<Exception> e(new Exception(
+            ExceptionType::kConferenceUnknown, "Subscribing this stream."));
+        on_failure(std::move(e));
+      });
+    }
+  }
+  subscribe_success_callback_ = on_success;
+  failure_callback_ = on_failure;
+  sio::message::ptr sio_options = sio::object_message::create();
+  sio::message::ptr media_options = sio::object_message::create();
+  if (stream->has_audio_ && !subscribe_options.audio.disabled) {
+    sio::message::ptr audio_options = sio::object_message::create();
+    audio_options->get_map()["from"] =
+        sio::string_message::create(stream->Id());
+    media_options->get_map()["audio"] = audio_options;
+  } else {
+    media_options->get_map()["audio"] = sio::bool_message::create(false);
+  }
+  if (stream->has_video_ && !subscribe_options.video.disabled) {
+    sio::message::ptr video_options = sio::object_message::create();
+    video_options->get_map()["from"] =
+        sio::string_message::create(stream->Id());
+    sio::message::ptr video_spec = sio::object_message::create();
+    sio::message::ptr resolution_options = sio::object_message::create();
+    if (subscribe_options.video.resolution.width != 0 &&
+        subscribe_options.video.resolution.height != 0) {
+      resolution_options->get_map()["width"] =
+          sio::int_message::create(subscribe_options.video.resolution.width);
+      resolution_options->get_map()["height"] =
+          sio::int_message::create(subscribe_options.video.resolution.height);
+      video_spec->get_map()["resolution"] = resolution_options;
+    }
+    // If bitrateMultiplier is not specified, do not include it in video spec.
+    std::string quality_level("x1.0");
+    if (subscribe_options.video.bitrateMultiplier != 0) {
+      quality_level =
+          "x" + std::to_string(subscribe_options.video.bitrateMultiplier)
+                    .substr(0, 3);
+    }
+    if (quality_level != "x1.0") {
+      sio::message::ptr quality_options =
+          sio::string_message::create(quality_level);
+      video_spec->get_map()["bitrate"] = quality_options;
+    }
+    if (subscribe_options.video.keyFrameInterval != 0) {
+      video_spec->get_map()["keyFrameInterval"] =
+          sio::int_message::create(subscribe_options.video.keyFrameInterval);
+    }
+    if (subscribe_options.video.frameRate != 0) {
+      video_spec->get_map()["framerate"] =
+          sio::int_message::create(subscribe_options.video.frameRate);
+    }
+    video_options->get_map()["parameters"] = video_spec;
+    if (subscribe_options.video.rid != "") {
+      video_options->get_map()["simulcastRid"] =
+          sio::string_message::create(subscribe_options.video.rid);
+    }
+    media_options->get_map()["video"] = video_options;
+  } else {
+    media_options->get_map()["video"] = sio::bool_message::create(false);
+  }
+  sio_options->get_map()["media"] = media_options;
+  if (stream->has_audio_ && !subscribe_options.audio.disabled) {
+    webrtc::RtpTransceiverInit transceiver_init;
+    transceiver_init.direction = webrtc::RtpTransceiverDirection::kRecvOnly;
+    AddTransceiver(cricket::MediaType::MEDIA_TYPE_AUDIO, transceiver_init);
+  }
+  if (stream->has_video_ && !subscribe_options.video.disabled) {
+    webrtc::RtpTransceiverInit transceiver_init;
+    transceiver_init.direction = webrtc::RtpTransceiverDirection::kRecvOnly;
+    AddTransceiver(cricket::MediaType::MEDIA_TYPE_VIDEO, transceiver_init);
+  }
+  signaling_channel_->SendInitializationMessage(
+      sio_options, "", stream->Id(),
+      [this](std::string session_id) {
+        // Pre-set the session's ID.
+        SetSessionId(session_id);
+      },
+      on_failure);  // TODO: on_failure
+}
+void ConferencWebTransportChannel::Unpublish(
+    const std::string& session_id,
+    std::function<void()> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  if (session_id != GetSessionId()) {
+    RTC_LOG(LS_ERROR) << "Publication ID mismatch.";
+    if (on_failure != nullptr) {
+      event_queue_->PostTask([on_failure]() {
+        std::unique_ptr<Exception> e(
+            new Exception(ExceptionType::kConferenceUnknown,
+                          "Invalid stream to be unpublished."));
+        on_failure(std::move(e));
+      });
+    }
+    return;
+  }
+  connected_ = false;
+  signaling_channel_->SendStreamEvent("unpublish", session_id,
+                                      RunInEventQueue(on_success), on_failure);
+}
+void ConferenceWebTransportChannel::Unsubscribe(
+    const std::string& session_id,
+    std::function<void()> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  if (session_id != GetSessionId()) {
+    RTC_LOG(LS_ERROR) << "Subscription ID mismatch.";
+    if (on_failure != nullptr) {
+      event_queue_->PostTask([on_failure]() {
+        std::unique_ptr<Exception> e(
+            new Exception(ExceptionType::kConferenceUnknown,
+                          "Invalid stream to be unsubscribed."));
+        on_failure(std::move(e));
+      });
+    }
+    return;
+  }
+  if (subscribe_success_callback_ != nullptr) {  // Subscribing
+    if (on_failure != nullptr) {
+      event_queue_->PostTask([on_failure]() {
+        std::unique_ptr<Exception> e(
+            new Exception(ExceptionType::kConferenceUnknown,
+                          "Cannot unsubscribe a stream during subscribing."));
+        on_failure(std::move(e));
+      });
+    }
+    return;
+  }
+  connected_ = false;
+  signaling_channel_->SendStreamEvent("unsubscribe", session_id,
+                                      RunInEventQueue(on_success), on_failure);
+}
+void ConferenceWebTransportChannel::SendStreamControlMessage(
+    const std::string& in_action,
+    const std::string& out_action,
+    const std::string& operation,
+    std::function<void()> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) const {
+  std::string action = "";
+  if (published_stream_) {
+    action = out_action;
+    signaling_channel_->SendStreamControlMessage(session_id_, action, operation,
+                                                 on_success, on_failure);
+  } else if (subscribed_stream_) {
+    action = in_action;
+    signaling_channel_->SendSubscriptionControlMessage(
+        session_id_, action, operation, on_success, on_failure);
+  } else
+    RTC_DCHECK(false);
+}
+
+// TODO: the webtransport channel implementation should not depend
+// on specific signaling protocol such as Socket.IO.
+void ConferencWebTransportChannel::OnSignalingMessage(
+    sio::message::ptr message) {
+  if (message == nullptr) {
+    RTC_LOG(LS_INFO) << "Ignore empty signaling message";
+    return;
+  }
+  if (message->get_flag() == sio::message::flag_string) {
+    if (message->get_string() == "success") {
+      std::weak_ptr<ConferenceWebTransportChannel> weak_this =
+          shared_from_this();
+      if (publish_success_callback_) {
+        event_queue_->PostTask([weak_this] {
+          auto that = weak_this.lock();
+          std::lock_guard<std::mutex> lock(that->callback_mutex_);
+          if (!that || !that->publish_success_callback_)
+            return;
+          that->publish_success_callback_(that->GetSessionId());
+          that->ResetCallbacks();
+        });
+      } else if (subscribe_success_callback_) {
+        bool stream_added = false;
+        {
+          std::lock_guard<std::mutex> lock(sub_stream_added_mutex_);
+          stream_added = sub_stream_added_;
+          sub_server_ready_ = true;
+          if (stream_added) {
+            event_queue_->PostTask([weak_this] {
+              auto that = weak_this.lock();
+              std::lock_guard<std::mutex> lock(that->callback_mutex_);
+              if (!that || !that->subscribe_success_callback_)
+                return;
+              that->subscribe_success_callback_(that->GetSessionId());
+              that->ResetCallbacks();
+            });
+            sub_server_ready_ = false;
+            sub_stream_added_ = false;
+          }
+        }
+      }
+      return;
+    } else if (message->get_string() == "failure") {
+      if (!connected_ && failure_callback_) {
+        std::weak_ptr<ConferenceWebTransportChannel> weak_this =
+            shared_from_this();
+        event_queue_->PostTask([weak_this] {
+          auto that = weak_this.lock();
+          std::lock_guard<std::mutex> lock(that->callback_mutex_);
+          if (!that || !that->failure_callback_)
+            return;
+          std::unique_ptr<Exception> e(new Exception(
+              ExceptionType::kConferenceUnknown,
+              "MCU internal error during connection establishment."));
+          that->failure_callback_(std::move(e));
+          that->ResetCallbacks();
+        });
+      }
+    }
+    return;
+  } else if (message->get_flag() != sio::message::flag_object) {
+    RTC_LOG(LS_WARNING) << "Ignore invalid signaling message from MCU.";
+    return;
+  }
+  // Since trickle ICE from MCU is not supported, we parse the message as
+  // SOAC message, not Canddiate message.
+  if (message->get_map().find("type") == message->get_map().end()) {
+    RTC_LOG(LS_INFO) << "Ignore erizo message without type from MCU.";
+    return;
+  }
+  if (message->get_map()["type"]->get_flag() != sio::message::flag_string ||
+      message->get_map()["sdp"] == nullptr ||
+      message->get_map()["sdp"]->get_flag() != sio::message::flag_string) {
+    RTC_LOG(LS_ERROR) << "Invalid signaling message";
+    return;
+  }
+  const std::string type = message->get_map()["type"]->get_string();
+  RTC_LOG(LS_INFO) << "On signaling message: " << type;
+  if (type == "answer") {
+    const std::string sdp = message->get_map()["sdp"]->get_string();
+    SetRemoteDescription(type, sdp);
+  } else {
+    RTC_LOG(LS_ERROR)
+        << "Ignoring signaling message from server other than answer.";
+  }
+}
+
+std::string ConferenceWebTransportChannel::GetSubStreamId() {
+  if (subscribed_stream_) {
+    return subscribed_stream_->Id();
+  } else {
+    return "";
+  }
+}
+
+void ConferenceWebTransportChannel::SetSessionId(const std::string& id) {
+  RTC_LOG(LS_INFO) << "Setting session ID for current channel";
+  session_id_ = id;
+}
+
+std::string ConferenceWebTransportChannel::GetSessionId() const {
+  return session_id_;
+}
+
+void ConferenceWebTransportChannel::SendPublishMessage(
+    sio::message::ptr options,
+    std::shared_ptr<owt::base::LocalStream> stream,
+    std::function<void(std::unique_ptr<owt::base::Exception>)> on_failure) {
+  std::weak_ptr<ConferenceWebTransportChannel> weak_this = shared_from_this();
+  signaling_channel_->SendInitializationMessage(
+      options, stream->MediaStream()->id(), "",
+      [stream, weak_this, on_failure](std::string session_id, std::string publication_id) {
+        auto that = weak_this.lock();
+        if (!that)
+        SetSessionId(session_id);
+      },
+      on_failure);
+}
+
+void ConferenceWebTransportChannel::OnStreamError(
+    const std::string& error_message) {
+  std::shared_ptr<const Exception> e(
+      new Exception(ExceptionType::kConferenceUnknown, error_message));
+  std::shared_ptr<Stream> error_stream;
+  for (auto its = observers_.begin(); its != observers_.end(); ++its) {
+    RTC_LOG(LS_INFO) << "On stream error.";
+    (*its).get().OnStreamError(error_stream, e);
+  }
+  if (published_stream_) {
+    Unpublish(GetSessionId(), nullptr, nullptr);
+    error_stream = published_stream_;
+  }
+  if (subscribed_stream_) {
+    Unsubscribe(GetSessionId(), nullptr, nullptr);
+    error_stream = subscribed_stream_;
+  }
+  if (error_stream == nullptr) {
+    RTC_DCHECK(false);
+    return;
+  }
+}
+
+std::function<void()> ConferenceWebTransportChannel::RunInEventQueue(
+    std::function<void()> func) {
+  if (!func)
+    return nullptr;
+  std::weak_ptr<ConferenceWebTransportChannel> weak_this = shared_from_this();
+  return [func, weak_this] {
+    auto that = weak_this.lock();
+    if (!that)
+      return;
+    that->event_queue_->PostTask([func] { func(); });
+  };
+}
+void ConferenceWebTransportChannel::ResetCallbacks() {
+  publish_success_callback_ = nullptr;
+  subscribe_success_callback_ = nullptr;
+  failure_callback_ = nullptr;
+}
+
+void ConferenceWebTransportChannel::OnConnected() {
+  RTC_LOG(LS_INFO) << "Quic client connected.";
+  quic_client_connected_ = true;
+  if (observer_) {
+    observer_->OnConnected();
+  }
+}
+
+void ConferenceWebTransportChannel::OnConnectionFailed() {
+  RTC_LOG(LS_INFO) << "Quic client disconnected.";
+  quic_client_connected_ = false;
+  if (observer_) {
+    observer_->OnConnectionFailed();
+  }
+}
+
+void ConferenceWebTransportChannel::OnIncomingStream(
+    owt::quic::QuicTransportStreamInterface* stream) {
+  // Suppose this should not get invoked.
+  RTC_LOG(LS_INFO) << "Incoming quic stream.";
+  if (observer_) {
+    observer_->OnIncomingStream(stream);
+  }
+}
+
+void ConferenceWebTransportChannel::CreateSendStream(
+    std::function<void(std::shared_ptr<owt::base::WritableStream>)> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  if (!on_success) {
+    RTC_LOG(LS_WARNING) << "No success callback provided. Do nothing.";
+    return;
+  }
+  if (!quic_transport_client_.get() || !quic_client_connected_) {
+    if (on_failure != nullptr) {
+      event_queue_->PostTask([on_failure]() {
+        std::unique_ptr<Exception> e(new Exception(
+            ExceptionType::kConferenceUnknown,
+            "Cannot create send stream without quic server connected."));
+        on_failure(std::move(e));
+      });
+    }
+    return;
+  }
+  // Sychronous call for creating the stream.
+  owt::quic::QuicTransportStreamInterface* quic_stream =
+      quic_transport_client_->CreateOutgoingUnidirectionalStream();
+  on_success(std::make_shared<owt::base::WritableStream>(quic_stream));
+}
+
+}  // namespace conference
+}  // namespace owt

--- a/talk/owt/sdk/conference/conferencewebtransportchannel.cc
+++ b/talk/owt/sdk/conference/conferencewebtransportchannel.cc
@@ -3,19 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "talk/owt/sdk/conference/conferencewebtransportchannel.h"
 #include <future>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
 #include "talk/owt/sdk/base/functionalobserver.h"
 #include "talk/owt/sdk/base/mediautils.h"
+#include "talk/owt/sdk/include/cpp/owt/base/stream.h"
 #include "talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h"
 #include "webrtc/rtc_base/checks.h"
 #include "webrtc/rtc_base/logging.h"
+#include "owt/quic/quic_definitions.h"
 #include "owt/quic/quic_transport_client_interface.h"
 #include "owt/quic/quic_transport_factory.h"
 #include "owt/quic/quic_transport_stream_interface.h"
 
 using namespace rtc;
+using namespace owt::quic;
+
 namespace owt {
 namespace conference {
 using std::string;
@@ -25,20 +31,20 @@ const std::string kStreamOptionStreamIdKey = "streamId";
 const std::string kStreamOptionStateKey = "state";
 const std::string kStreamOptionDataKey = "type";
 const std::string kStreamOptionWebTransportKey = "data";
-const std::string kStreamOptionScreenKey = "screen";
 const std::string kStreamOptionAttributesKey = "attributes";
 
 ConferenceWebTransportChannel::ConferenceWebTransportChannel(
     const std::string& url,
+    const std::string& webtransport_id,
+    const std::string& webtransport_token,
     std::shared_ptr<ConferenceSocketSignalingChannel> signaling_channel,
     std::shared_ptr<rtc::TaskQueue> event_queue)
     : signaling_channel_(signaling_channel),
-      session_id_(""),
       connected_(false),
-      sub_stream_added_(false),
-      sub_server_ready_(false),
       event_queue_(event_queue),
-      url_(url) {
+      url_(url),
+      transport_id_(webtransport_id),
+      webtransport_token_(webtransport_token) {
   quic_transport_factory_.reset(owt::quic::QuicTransportFactory::Create());
   quic_client_connected_ = false;
   RTC_CHECK(signaling_channel_);
@@ -46,10 +52,22 @@ ConferenceWebTransportChannel::ConferenceWebTransportChannel(
 
 ConferenceWebTransportChannel::~ConferenceWebTransportChannel() {
   RTC_LOG(LS_INFO) << "Deconstruct conference WebTransport channel";
-  if (published_stream_)
-    Unpublish(GetSessionId(), nullptr, nullptr);
-  if (subscribed_stream_)
-    Unsubscribe(GetSessionId(), nullptr, nullptr);
+  // We will rely on conference client to stop all publications/subscriptions.
+}
+
+void ConferenceWebTransportChannel::Authenticate() {
+  // Send the transportTicket acquired on joining.
+  if (!auth_stream_)
+    return;
+  // 128-bit of zero indicates this is a stream for signaling.
+  uint8_t signaling_stream_id[16] = {0};
+  auth_stream_->Write(&signaling_stream_id[0], 16);
+  // Send token as described in
+  // https://github.com/open-webrtc-toolkit/owt-server/blob/20e8aad216cc446095f63c409339c34c7ee770ee/doc/design/quic-transport-payload-format.md.
+  uint32_t token_size = webtransport_token_.length();
+  memcpy(&signaling_stream_id[0], &token_size, sizeof(uint32_t));
+  auth_stream_->Write(&signaling_stream_id[0], sizeof(uint32_t));
+  auth_stream_->Write((uint8_t*)(webtransport_token_.c_str()), token_size);
 }
 
 void ConferenceWebTransportChannel::Connect() {
@@ -60,20 +78,19 @@ void ConferenceWebTransportChannel::Connect() {
   owt::quic::QuicTransportClientInterface::Parameters quic_params;
   memset(&quic_params, 0, sizeof(quic_params));
   if (cert_fingerprint_size > 0) {
-    quic_params.server_certificate_fingerprints =
+    *(quic_params.server_certificate_fingerprints) =
         new owt::quic::CertificateFingerprint[cert_fingerprint_size];
     quic_params.server_certificate_fingerprints_length = cert_fingerprint_size;
   }
   int fingerprint_idx = 0;
   for (auto fingerprint : trusted_fingerprints) {
-    quic_params.server_certificate_fingerprints[fingerprint_idx] =
-        new char[QUIC_CERT_FINGERPRINT_SIZE];
-    memcpy(&quic_params.server_certificate_fingerprints[fingerprint_idx],
+    memcpy(quic_params.server_certificate_fingerprints[fingerprint_idx],
            fingerprint.data(), fingerprint.size());
   }
-  quic_transport_client = quic_transport_factory_->CreateQuicTransportClient(url_.c_str(), quic_params);
+  quic_transport_client_.reset(quic_transport_factory_->CreateQuicTransportClient(
+      url_.c_str(), quic_params));
   if (quic_transport_client_.get()) {
-    quic_transport_client_->SetVistor(this);
+    quic_transport_client_->SetVisitor(this);
     // Async. Connect status will be notified through visitor.
     quic_transport_client_->Connect();
   }
@@ -84,8 +101,7 @@ void ConferenceWebTransportChannel::AddObserver(
   RTC_CHECK(observer);
   observer_ = observer;
 }
-void ConferenceWebTransportChannel::RemoveObserver(
-    ConferenceWebTransportChannelObserver& observer) {
+void ConferenceWebTransportChannel::RemoveObserver() {
   observer_ = nullptr;
 }
 
@@ -107,17 +123,13 @@ bool ConferenceWebTransportChannel::CheckNullPointer(
 // conference client to construct the ConferencePublication instance,
 // So we're not passing success callback here.
 void ConferenceWebTransportChannel::Publish(
-    std::shared_ptr<LocalStream> stream,
+    std::shared_ptr<owt::base::LocalStream> stream,
     std::function<void(std::string, std::string)> on_success,
-    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+    std::function<void(std::unique_ptr<owt::base::Exception>)> on_failure) {
   RTC_LOG(LS_INFO) << "Publish a local stream.";
-  published_stream_ = stream;
-  if ((!CheckNullPointer((uintptr_t)stream.get(), on_failure)) ||
-      (!CheckNullPointer((uintptr_t)stream->QuicStream(), on_failure))) {
+  if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
     RTC_LOG(LS_INFO) << "Local stream cannot be nullptr.";
   }
-  publish_success_callback_ = on_success;
-  failure_callback_ = on_failure;
   sio::message::ptr options = sio::object_message::create();
   // attributes
   sio::message::ptr attributes_ptr = sio::object_message::create();
@@ -132,337 +144,144 @@ void ConferenceWebTransportChannel::Publish(
   options->get_map()["data"] = sio::bool_message::create(true);
   sio::message::ptr transport_ptr = sio::object_message::create();
   transport_ptr->get_map()["type"] = sio::string_message::create("quic");
-  transport_ptr->get_map()["id"] = sio::null_message::create();
-  SendPublishMessage(options, stream, on_failure);
+  transport_ptr->get_map()["id"] = sio::string_message::create(transport_id_);
+  SendPublishMessage(options, stream, on_success, on_failure);
 }
 
-// For WebTransport streams we will not check the subscription capabilities,
-// as it does not contain any optional settings.
-static bool SubOptionAllowed(
-    const SubscribeOptions& subscribe_options,
-    const PublicationSettings& publication_settings) {
-  if (subscribe_options.data.enabled && publication_settings.data.enabled)
-    return true;
-  return false;
-}
+
 void ConferenceWebTransportChannel::Subscribe(
-    std::shared_ptr<RemoteStream> stream,
-    const SubscribeOptions& subscribe_options,
+    std::shared_ptr<owt::base::RemoteStream> stream,
     std::function<void(std::string)> on_success,
     std::function<void(std::unique_ptr<owt::base::Exception>)> on_failure) {
-  RTC_LOG(LS_INFO) << "Subscribe a remote stream. It supports data? "
-                   << stream->DataEnabled();
-  if (!SubOptionAllowed(subscribe_options, stream->Settings())) {
-    RTC_LOG(LS_ERROR)
-        << "Subscribe option mismatch with stream subcription capabilities.";
-    if (on_failure != nullptr) {
-      event_queue_->PostTask([on_failure]() {
-        std::unique_ptr<Exception> e(
-            new Exception(ExceptionType::kConferenceUnknown,
-                          "Unsupported subscribe option."));
-        on_failure(std::move(e));
-      });
-    }
-    return;
-  }
-  subscribed_stream_ = stream;
   if (!CheckNullPointer((uintptr_t)stream.get(), on_failure)) {
     RTC_LOG(LS_ERROR) << "Remote stream cannot be nullptr.";
     return;
   }
-  if (subscribe_success_callback_) {
+  if (!stream->DataEnabled()) {
     if (on_failure) {
       event_queue_->PostTask([on_failure]() {
         std::unique_ptr<Exception> e(new Exception(
-            ExceptionType::kConferenceUnknown, "Subscribing this stream."));
+            ExceptionType::kConferenceUnknown, "Non-data stream not supported by WebTransport."));
         on_failure(std::move(e));
       });
     }
   }
-  subscribe_success_callback_ = on_success;
-  failure_callback_ = on_failure;
+
   sio::message::ptr sio_options = sio::object_message::create();
   sio::message::ptr media_options = sio::object_message::create();
-  if (stream->has_audio_ && !subscribe_options.audio.disabled) {
-    sio::message::ptr audio_options = sio::object_message::create();
-    audio_options->get_map()["from"] =
-        sio::string_message::create(stream->Id());
-    media_options->get_map()["audio"] = audio_options;
-  } else {
-    media_options->get_map()["audio"] = sio::bool_message::create(false);
-  }
-  if (stream->has_video_ && !subscribe_options.video.disabled) {
-    sio::message::ptr video_options = sio::object_message::create();
-    video_options->get_map()["from"] =
-        sio::string_message::create(stream->Id());
-    sio::message::ptr video_spec = sio::object_message::create();
-    sio::message::ptr resolution_options = sio::object_message::create();
-    if (subscribe_options.video.resolution.width != 0 &&
-        subscribe_options.video.resolution.height != 0) {
-      resolution_options->get_map()["width"] =
-          sio::int_message::create(subscribe_options.video.resolution.width);
-      resolution_options->get_map()["height"] =
-          sio::int_message::create(subscribe_options.video.resolution.height);
-      video_spec->get_map()["resolution"] = resolution_options;
-    }
-    // If bitrateMultiplier is not specified, do not include it in video spec.
-    std::string quality_level("x1.0");
-    if (subscribe_options.video.bitrateMultiplier != 0) {
-      quality_level =
-          "x" + std::to_string(subscribe_options.video.bitrateMultiplier)
-                    .substr(0, 3);
-    }
-    if (quality_level != "x1.0") {
-      sio::message::ptr quality_options =
-          sio::string_message::create(quality_level);
-      video_spec->get_map()["bitrate"] = quality_options;
-    }
-    if (subscribe_options.video.keyFrameInterval != 0) {
-      video_spec->get_map()["keyFrameInterval"] =
-          sio::int_message::create(subscribe_options.video.keyFrameInterval);
-    }
-    if (subscribe_options.video.frameRate != 0) {
-      video_spec->get_map()["framerate"] =
-          sio::int_message::create(subscribe_options.video.frameRate);
-    }
-    video_options->get_map()["parameters"] = video_spec;
-    if (subscribe_options.video.rid != "") {
-      video_options->get_map()["simulcastRid"] =
-          sio::string_message::create(subscribe_options.video.rid);
-    }
-    media_options->get_map()["video"] = video_options;
-  } else {
-    media_options->get_map()["video"] = sio::bool_message::create(false);
-  }
   sio_options->get_map()["media"] = media_options;
-  if (stream->has_audio_ && !subscribe_options.audio.disabled) {
-    webrtc::RtpTransceiverInit transceiver_init;
-    transceiver_init.direction = webrtc::RtpTransceiverDirection::kRecvOnly;
-    AddTransceiver(cricket::MediaType::MEDIA_TYPE_AUDIO, transceiver_init);
-  }
-  if (stream->has_video_ && !subscribe_options.video.disabled) {
-    webrtc::RtpTransceiverInit transceiver_init;
-    transceiver_init.direction = webrtc::RtpTransceiverDirection::kRecvOnly;
-    AddTransceiver(cricket::MediaType::MEDIA_TYPE_VIDEO, transceiver_init);
-  }
+  sio::message::ptr transport_options = sio::object_message::create();
+  transport_options->get_map()["type"] = sio::string_message::create("quic");
+  transport_options->get_map()["id"] =
+      sio::string_message::create(transport_id_);
+  sio::message::ptr data_options = sio::object_message::create();
+  data_options->get_map()["from"] =
+      sio::string_message::create(stream->Origin());
   signaling_channel_->SendInitializationMessage(
-      sio_options, "", stream->Id(),
-      [this](std::string session_id) {
-        // Pre-set the session's ID.
-        SetSessionId(session_id);
+      sio_options, "", "data-stream",
+      [this, on_success, on_failure](std::string session_id,
+                                     std::string transport_id) {
+        if (on_success) {
+          on_success(session_id);
+        }
       },
       on_failure);  // TODO: on_failure
 }
-void ConferencWebTransportChannel::Unpublish(
+
+void ConferenceWebTransportChannel::Unpublish(
     const std::string& session_id,
     std::function<void()> on_success,
-    std::function<void(std::unique_ptr<Exception>)> on_failure) {
-  if (session_id != GetSessionId()) {
-    RTC_LOG(LS_ERROR) << "Publication ID mismatch.";
+    std::function<void(std::unique_ptr<owt::base::Exception>)> on_failure) {
+  const std::lock_guard<std::mutex> lock(published_session_ids_mutex_);
+  auto itr = std::find(published_session_ids_.begin(),
+                       published_session_ids_.end(), session_id);
+  if (itr == published_session_ids_.end()) {
+    RTC_LOG(LS_ERROR) << "No publication matches session id:" << session_id;
     if (on_failure != nullptr) {
       event_queue_->PostTask([on_failure]() {
-        std::unique_ptr<Exception> e(
-            new Exception(ExceptionType::kConferenceUnknown,
-                          "Invalid stream to be unpublished."));
+        std::unique_ptr<owt::base::Exception> e(new owt::base::Exception(
+            owt::base::ExceptionType::kConferenceUnknown,
+            "Invalid session to be unpublishd."));
         on_failure(std::move(e));
       });
     }
     return;
   }
-  connected_ = false;
   signaling_channel_->SendStreamEvent("unpublish", session_id,
                                       RunInEventQueue(on_success), on_failure);
+  published_session_ids_.erase(itr);
 }
+
 void ConferenceWebTransportChannel::Unsubscribe(
     const std::string& session_id,
     std::function<void()> on_success,
-    std::function<void(std::unique_ptr<Exception>)> on_failure) {
-  if (session_id != GetSessionId()) {
-    RTC_LOG(LS_ERROR) << "Subscription ID mismatch.";
+    std::function<void(std::unique_ptr<owt::base::Exception>)> on_failure) {
+  std::lock_guard<std::mutex> lock(subscribed_session_ids_mutex_);
+  auto itr = std::find(subscribed_session_ids_.begin(),
+                       subscribed_session_ids_.end(), session_id);
+  if (itr == subscribed_session_ids_.end()) {
+    RTC_LOG(LS_ERROR) << "No subscription matches session id:" << session_id;
     if (on_failure != nullptr) {
       event_queue_->PostTask([on_failure]() {
-        std::unique_ptr<Exception> e(
-            new Exception(ExceptionType::kConferenceUnknown,
-                          "Invalid stream to be unsubscribed."));
+        std::unique_ptr<owt::base::Exception> e(
+            new owt::base::Exception(owt::base::ExceptionType::kConferenceUnknown,
+                          "Invalid session to be unsubscribed."));
         on_failure(std::move(e));
       });
     }
     return;
   }
-  if (subscribe_success_callback_ != nullptr) {  // Subscribing
-    if (on_failure != nullptr) {
-      event_queue_->PostTask([on_failure]() {
-        std::unique_ptr<Exception> e(
-            new Exception(ExceptionType::kConferenceUnknown,
-                          "Cannot unsubscribe a stream during subscribing."));
-        on_failure(std::move(e));
-      });
-    }
-    return;
-  }
-  connected_ = false;
   signaling_channel_->SendStreamEvent("unsubscribe", session_id,
                                       RunInEventQueue(on_success), on_failure);
+  subscribed_session_ids_.erase(itr);
 }
+
 void ConferenceWebTransportChannel::SendStreamControlMessage(
+    const std::string& session_id,
     const std::string& in_action,
     const std::string& out_action,
     const std::string& operation,
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) const {
   std::string action = "";
-  if (published_stream_) {
+  // Check if this session is pub or sub.
+  auto itr_pub = std::find(published_session_ids_.begin(),
+                       published_session_ids_.end(), session_id);
+  auto itr_sub = std::find(subscribed_session_ids_.begin(),
+                           subscribed_session_ids_.end(), session_id);
+  if (itr_pub != published_session_ids_.end() && out_action != "") {
     action = out_action;
-    signaling_channel_->SendStreamControlMessage(session_id_, action, operation,
+    signaling_channel_->SendStreamControlMessage(session_id, action, operation,
                                                  on_success, on_failure);
-  } else if (subscribed_stream_) {
+  } else if (itr_sub != subscribed_session_ids_.end() && in_action != "") {
     action = in_action;
     signaling_channel_->SendSubscriptionControlMessage(
-        session_id_, action, operation, on_success, on_failure);
-  } else
-    RTC_DCHECK(false);
-}
-
-// TODO: the webtransport channel implementation should not depend
-// on specific signaling protocol such as Socket.IO.
-void ConferencWebTransportChannel::OnSignalingMessage(
-    sio::message::ptr message) {
-  if (message == nullptr) {
-    RTC_LOG(LS_INFO) << "Ignore empty signaling message";
-    return;
+        session_id, action, operation, on_success, on_failure);
   }
-  if (message->get_flag() == sio::message::flag_string) {
-    if (message->get_string() == "success") {
-      std::weak_ptr<ConferenceWebTransportChannel> weak_this =
-          shared_from_this();
-      if (publish_success_callback_) {
-        event_queue_->PostTask([weak_this] {
-          auto that = weak_this.lock();
-          std::lock_guard<std::mutex> lock(that->callback_mutex_);
-          if (!that || !that->publish_success_callback_)
-            return;
-          that->publish_success_callback_(that->GetSessionId());
-          that->ResetCallbacks();
-        });
-      } else if (subscribe_success_callback_) {
-        bool stream_added = false;
-        {
-          std::lock_guard<std::mutex> lock(sub_stream_added_mutex_);
-          stream_added = sub_stream_added_;
-          sub_server_ready_ = true;
-          if (stream_added) {
-            event_queue_->PostTask([weak_this] {
-              auto that = weak_this.lock();
-              std::lock_guard<std::mutex> lock(that->callback_mutex_);
-              if (!that || !that->subscribe_success_callback_)
-                return;
-              that->subscribe_success_callback_(that->GetSessionId());
-              that->ResetCallbacks();
-            });
-            sub_server_ready_ = false;
-            sub_stream_added_ = false;
-          }
-        }
-      }
-      return;
-    } else if (message->get_string() == "failure") {
-      if (!connected_ && failure_callback_) {
-        std::weak_ptr<ConferenceWebTransportChannel> weak_this =
-            shared_from_this();
-        event_queue_->PostTask([weak_this] {
-          auto that = weak_this.lock();
-          std::lock_guard<std::mutex> lock(that->callback_mutex_);
-          if (!that || !that->failure_callback_)
-            return;
-          std::unique_ptr<Exception> e(new Exception(
-              ExceptionType::kConferenceUnknown,
-              "MCU internal error during connection establishment."));
-          that->failure_callback_(std::move(e));
-          that->ResetCallbacks();
-        });
-      }
-    }
-    return;
-  } else if (message->get_flag() != sio::message::flag_object) {
-    RTC_LOG(LS_WARNING) << "Ignore invalid signaling message from MCU.";
-    return;
-  }
-  // Since trickle ICE from MCU is not supported, we parse the message as
-  // SOAC message, not Canddiate message.
-  if (message->get_map().find("type") == message->get_map().end()) {
-    RTC_LOG(LS_INFO) << "Ignore erizo message without type from MCU.";
-    return;
-  }
-  if (message->get_map()["type"]->get_flag() != sio::message::flag_string ||
-      message->get_map()["sdp"] == nullptr ||
-      message->get_map()["sdp"]->get_flag() != sio::message::flag_string) {
-    RTC_LOG(LS_ERROR) << "Invalid signaling message";
-    return;
-  }
-  const std::string type = message->get_map()["type"]->get_string();
-  RTC_LOG(LS_INFO) << "On signaling message: " << type;
-  if (type == "answer") {
-    const std::string sdp = message->get_map()["sdp"]->get_string();
-    SetRemoteDescription(type, sdp);
-  } else {
-    RTC_LOG(LS_ERROR)
-        << "Ignoring signaling message from server other than answer.";
-  }
-}
-
-std::string ConferenceWebTransportChannel::GetSubStreamId() {
-  if (subscribed_stream_) {
-    return subscribed_stream_->Id();
-  } else {
-    return "";
-  }
-}
-
-void ConferenceWebTransportChannel::SetSessionId(const std::string& id) {
-  RTC_LOG(LS_INFO) << "Setting session ID for current channel";
-  session_id_ = id;
-}
-
-std::string ConferenceWebTransportChannel::GetSessionId() const {
-  return session_id_;
 }
 
 void ConferenceWebTransportChannel::SendPublishMessage(
     sio::message::ptr options,
     std::shared_ptr<owt::base::LocalStream> stream,
+    std::function <void(std::string session_id, std::string transport_id)> on_success,
     std::function<void(std::unique_ptr<owt::base::Exception>)> on_failure) {
-  std::weak_ptr<ConferenceWebTransportChannel> weak_this = shared_from_this();
+  std::weak_ptr<owt::conference::ConferenceWebTransportChannel> weak_this = shared_from_this();
   signaling_channel_->SendInitializationMessage(
-      options, stream->MediaStream()->id(), "",
-      [stream, weak_this, on_failure](std::string session_id, std::string publication_id) {
+      options, "data-stream", "",
+      [stream, weak_this, on_success, on_failure](std::string session_id, std::string transport_id) {
         auto that = weak_this.lock();
-        if (!that)
-        SetSessionId(session_id);
+        if (that) {
+          if (on_success) {
+            on_success(session_id, transport_id);
+          }
+        }
       },
       on_failure);
 }
 
 void ConferenceWebTransportChannel::OnStreamError(
     const std::string& error_message) {
-  std::shared_ptr<const Exception> e(
-      new Exception(ExceptionType::kConferenceUnknown, error_message));
-  std::shared_ptr<Stream> error_stream;
-  for (auto its = observers_.begin(); its != observers_.end(); ++its) {
-    RTC_LOG(LS_INFO) << "On stream error.";
-    (*its).get().OnStreamError(error_stream, e);
-  }
-  if (published_stream_) {
-    Unpublish(GetSessionId(), nullptr, nullptr);
-    error_stream = published_stream_;
-  }
-  if (subscribed_stream_) {
-    Unsubscribe(GetSessionId(), nullptr, nullptr);
-    error_stream = subscribed_stream_;
-  }
-  if (error_stream == nullptr) {
-    RTC_DCHECK(false);
-    return;
-  }
+  // Not implemented.
 }
 
 std::function<void()> ConferenceWebTransportChannel::RunInEventQueue(
@@ -477,14 +296,13 @@ std::function<void()> ConferenceWebTransportChannel::RunInEventQueue(
     that->event_queue_->PostTask([func] { func(); });
   };
 }
-void ConferenceWebTransportChannel::ResetCallbacks() {
-  publish_success_callback_ = nullptr;
-  subscribe_success_callback_ = nullptr;
-  failure_callback_ = nullptr;
-}
 
 void ConferenceWebTransportChannel::OnConnected() {
   RTC_LOG(LS_INFO) << "Quic client connected.";
+  //Authenticate the client.
+  RTC_DCHECK(quic_transport_client_.get());
+  auth_stream_ = quic_transport_client_->CreateBidirectionalStream();
+  auth_stream_observer_ = std::make_unique<owt::conference::ConferenceWebTransportChannel::AuthStreamObserver>(this);
   quic_client_connected_ = true;
   if (observer_) {
     observer_->OnConnected();
@@ -499,17 +317,32 @@ void ConferenceWebTransportChannel::OnConnectionFailed() {
   }
 }
 
+// This gets called for subscription case. After sucessful
+// subscribe signaling, MCU will create the send stream on
+// server side, and this results in client's OnIncomingStream
+// to be invoked. MCU will further send the session id on the
+// incoming stream. This will be used to associate the stream
+// with subscription.
 void ConferenceWebTransportChannel::OnIncomingStream(
     owt::quic::QuicTransportStreamInterface* stream) {
-  // Suppose this should not get invoked.
+  // At the time of this callback, the session id is still unknown.
+  // We will need to wait until we read it over signaling session.
   RTC_LOG(LS_INFO) << "Incoming quic stream.";
+  owt::conference::ConferenceWebTransportChannel::IncomingStreamObserver* stream_observer =
+      new owt::conference::ConferenceWebTransportChannel::IncomingStreamObserver(this, stream);
+  stream->SetVisitor(stream_observer);
+}
+
+void ConferenceWebTransportChannel::OnStreamSessionId(const std::string& session_id,
+    owt::quic::QuicTransportStreamInterface* stream) {
+  // TODO: remove the stream observer for this stream first.
   if (observer_) {
-    observer_->OnIncomingStream(stream);
+    observer_->OnIncomingStream(session_id, stream);
   }
 }
 
 void ConferenceWebTransportChannel::CreateSendStream(
-    std::function<void(std::shared_ptr<owt::base::WritableStream>)> on_success,
+    std::function<void(std::shared_ptr<owt::base::LocalStream>)> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
   if (!on_success) {
     RTC_LOG(LS_WARNING) << "No success callback provided. Do nothing.";
@@ -528,8 +361,12 @@ void ConferenceWebTransportChannel::CreateSendStream(
   }
   // Sychronous call for creating the stream.
   owt::quic::QuicTransportStreamInterface* quic_stream =
-      quic_transport_client_->CreateOutgoingUnidirectionalStream();
-  on_success(std::make_shared<owt::base::WritableStream>(quic_stream));
+      quic_transport_client_->CreateBidirectionalStream();
+  // For local stream session id is not specified at stream creation time.
+  std::shared_ptr<owt::base::QuicStream> writable_stream =
+      std::make_shared<owt::base::QuicStream>(quic_stream, "0");
+  int error_code = 0;
+  on_success(owt::base::LocalStream::Create(writable_stream, error_code));
 }
 
 }  // namespace conference

--- a/talk/owt/sdk/conference/conferencewebtransportchannel.h
+++ b/talk/owt/sdk/conference/conferencewebtransportchannel.h
@@ -1,0 +1,144 @@
+// Copyright (C) <2018> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OWT_CONFERENCE_CONFERENCEWEBTRANSPORTCHANNEL_H_
+#define OWT_CONFERENCE_CONFERENCEWEBTRANSPORTCHANNEL_H_
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <chrono>
+#include <random>
+#include "webrtc/rtc_base/task_queue.h"
+#include "talk/owt/include/sio_message.h"
+#include "talk/owt/include/sio_client.h"
+#include "talk/owt/sdk/conference/conferencesocketsignalingchannel.h"
+#include "talk/owt/sdk/include/cpp/owt/base/exception.h"
+#include "talk/owt/sdk/include/cpp/owt/base/stream.h"
+#include "talk/owt/sdk/include/cpp/owt/conference/subscribeoptions.h"
+#include "talk/owt/sdk/include/cpp/owt/conference/conferencepublication.h"
+#include "talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h"
+
+namespace owt {
+
+namespace quic {
+class QuicTransportFactory;
+class QuicTransportClientInterface;
+}
+
+namespace conference {
+using namespace owt::base;
+
+// An instance of ConferenceWebTransportChannel manages a WebTransport channel with
+// MCU as well as it's signaling through Socket.IO.
+class ConferenceWebTransportChannel: public owt::quic::QuicTransportClientInterface::Visitor, 
+    public std::enable_shared_from_this<ConferenceWebTransportChannel> {
+ public:
+  explicit ConferenceWebTransportChannel(
+      const std::string& url,
+      std::shared_ptr<ConferenceSocketSignalingChannel> signaling_channel,
+      std::shared_ptr<rtc::TaskQueue> event_queue);
+  ~ConferenceWebTransportChannel();
+  // Connect asynchronously to WebTransport server.
+  void Connect();
+  // Create WritableStream
+  void CreateSendStream(
+      std::function<void(std::shared_ptr<owt::base::WritableStream>)>
+          on_success,
+      std::function<void(std::unique_ptr<Exception>)> on_failure);
+  // Add a ConferenceWebTransportChannel observer so it will be notified when
+  // this object have some events.
+  void AddObserver(ConferenceWebTransportChannelObserver* observer);
+  // Remove a ConferencePeerConnectionChannel observer. If the observer doesn't
+  // exist, it will do nothing.
+  void RemoveObserver();
+  // Publish a local stream to the conference.
+  void Publish(
+      std::shared_ptr<LocalStream> stream,
+      std::function<void(std::string)> on_success,
+      std::function<void(std::unique_ptr<Exception>)> on_failure);
+  // Unpublish a local stream to the conference.
+  void Unpublish(
+      const std::string& session_id,
+      std::function<void()> on_success,
+      std::function<void(std::unique_ptr<Exception>)> on_failure);
+  // Subscribe a stream from the conference.
+  void Subscribe(
+      std::shared_ptr<RemoteStream> stream,
+      const SubscribeOptions& options,
+      std::function<void(std::string)> on_success,
+      std::function<void(std::unique_ptr<Exception>)> on_failure);
+  // Unsubscribe a remote stream from the conference.
+  void Unsubscribe(
+      const std::string& session_id,
+      std::function<void()> on_success,
+      std::function<void(std::unique_ptr<Exception>)> on_failure);
+  // Stop current WebRTC session.
+  void Stop(
+      std::function<void()> on_success,
+      std::function<void(std::unique_ptr<Exception>)> on_failure);
+  // Get the associated stream id if it is a subscription channel.
+  std::string GetSubStreamId();
+  // Set stream's session ID. This ID is returned by MCU per publish/subscribe.
+  void SetSessionId(const std::string& id);
+  // Get published or subscribed stream's publicationID or subcriptionID.
+  std::string GetSessionId() const;
+  // Socket.IO event
+  virtual void OnSignalingMessage(sio::message::ptr message);
+  // TODO: define stats API
+  void OnStreamError(const std::string& error_message);
+ private:
+  // Overrides owt::quic::QuicTransportClientInterface::Visitor
+  void OnConnected();
+  void OnConnectionFailed();
+  void OnIncomingStream(QuicTransportStreamInterface*);
+  bool CheckNullPointer(
+      uintptr_t pointer,
+      std::function<void(std::unique_ptr<Exception>)> on_failure);
+  void SendStreamControlMessage(
+      const std::string& in_action,
+      const std::string& out_action,
+      const std::string& operation,
+      std::function<void()> on_success,
+      std::function<void(std::unique_ptr<Exception>)> on_failure)
+      const;
+  void SendPublishMessage(
+    sio::message::ptr options,
+    std::shared_ptr<LocalStream> stream,
+    std::function<void(std::unique_ptr<Exception>)> on_failure);
+  std::function<void()> RunInEventQueue(std::function<void()> func);
+  // Set publish_success_callback_, subscribe_success_callback_ and
+  // failure_callback_ to nullptr.
+  void ResetCallbacks();
+  std::shared_ptr<ConferenceSocketSignalingChannel> signaling_channel_;
+  std::string session_id_;   //session ID is 1:1 mapping to the subscribed/published stream.
+  // If this pc is used for publishing, |local_stream_| will be the stream to be
+  // published.
+  // Otherwise, |remote_stream_| will be the stream to be subscribed.
+  std::shared_ptr<RemoteStream> subscribed_stream_;
+  std::shared_ptr<LocalStream> published_stream_;
+  // Callbacks for publish or subscribe.
+  std::function<void(std::string)> publish_success_callback_;
+  std::function<void(std::string)> subscribe_success_callback_;
+  std::function<void(std::unique_ptr<Exception>)> failure_callback_;
+  std::mutex callback_mutex_;
+  ConferenceWebTransportChannelObserver* observer_;
+  bool connected_;
+  // Mutex for firing subscription succeed callback.
+  std::mutex sub_stream_added_mutex_;
+  bool sub_stream_added_;
+  bool sub_server_ready_;
+  // Queue for callbacks and events.
+  // Queue for callbacks and events.
+  std::shared_ptr<rtc::TaskQueue> event_queue_;
+  std::unique_ptr<QuicTransportFactory> quic_transport_factory_;
+  std::unique_ptr<QuicTransportClientInterface> quic_transport_client_;
+  // Each conference client will be associated with one quic_transport_channel_
+  // instance.
+  std::shared_ptr<ConferenceWebTransportChannel> quic_transport_channel_;
+  std::atomic<bool> quic_client_connected_;
+  std::string url_;
+
+};
+}
+}
+#endif  // OWT_CONFERENCE_CONFERENCEWEBTRANSPORTCHANNEL_H_

--- a/talk/owt/sdk/conference/conferencewebtransportchannel.h
+++ b/talk/owt/sdk/conference/conferencewebtransportchannel.h
@@ -1,8 +1,9 @@
-// Copyright (C) <2018> Intel Corporation
+// Copyright (C) <2020> Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_CONFERENCE_CONFERENCEWEBTRANSPORTCHANNEL_H_
 #define OWT_CONFERENCE_CONFERENCEWEBTRANSPORTCHANNEL_H_
+
 #include <chrono>
 #include <condition_variable>
 #include <memory>
@@ -30,7 +31,7 @@ using namespace owt::base;
 using namespace owt::quic;
 
 // An instance of ConferenceWebTransportChannel manages a WebTransport channel with
-// MCU as well as it's signaling through Socket.IO.
+// MCU as well as its signaling through Socket.IO.
 class ConferenceWebTransportChannel: public owt::quic::QuicTransportClientInterface::Visitor, 
     public std::enable_shared_from_this<ConferenceWebTransportChannel> {
  public:
@@ -46,19 +47,14 @@ class ConferenceWebTransportChannel: public owt::quic::QuicTransportClientInterf
    public:
     AuthStreamObserver(ConferenceWebTransportChannel* channel)
         : channel_(channel) {}
-    virtual void OnCanRead() {
-        RTC_LOG(LS_ERROR) << "On Can read.";
-    }
+    virtual void OnCanRead() {}
     virtual void OnCanWrite() {
-      RTC_LOG(LS_ERROR) << "On Can Write.";
       if (channel_ && !authenticated_) {
         channel_->Authenticate();
         authenticated_ = true;
       }
     }
-    virtual void OnFinRead() {
-        RTC_LOG(LS_ERROR) << "Fin Read";
-    }
+    virtual void OnFinRead() {}
    private:
     ConferenceWebTransportChannel* channel_;
     bool authenticated_ = false;
@@ -110,7 +106,9 @@ class ConferenceWebTransportChannel: public owt::quic::QuicTransportClientInterf
       const std::string& session_id,
       std::function<void()> on_success,
       std::function<void(std::unique_ptr<Exception>)> on_failure);
-  // Socket.IO event. WebTransport channel does not rely on this.
+  // Socket.IO event. WebTransport channel does not rely on this at
+  // present. TODO(jianlin): handle quic signaling message for progress
+  // update.
   virtual void OnSignalingMessage(sio::message::ptr message) {}
   // TODO: define stats API
   void OnStreamError(const std::string& error_message);
@@ -160,7 +158,6 @@ class ConferenceWebTransportChannel: public owt::quic::QuicTransportClientInterf
   mutable std::mutex published_session_ids_mutex_;
   std::vector<std::string> subscribed_session_ids_;
   mutable std::mutex subscribed_session_ids_mutex_;
-  // We cannot do authentication in the OnConnected callback.
   mutable std::mutex auth_mutex_;
   std::unique_ptr<std::condition_variable> auth_cv_;
 };

--- a/talk/owt/sdk/conference/conferencewebtransportchannel.h
+++ b/talk/owt/sdk/conference/conferencewebtransportchannel.h
@@ -36,6 +36,7 @@ class ConferenceWebTransportChannel: public owt::quic::QuicTransportClientInterf
     public std::enable_shared_from_this<ConferenceWebTransportChannel> {
  public:
   explicit ConferenceWebTransportChannel(
+      const ConferenceClientConfiguration& configuration,
       const std::string& url,
       const std::string& webtransport_id,
       const std::string& webtransport_token,
@@ -137,6 +138,7 @@ class ConferenceWebTransportChannel: public owt::quic::QuicTransportClientInterf
     std::function<void(std::unique_ptr<Exception>)> on_failure);
   std::function<void()> RunInEventQueue(std::function<void()> func);
   void AuthenticateCallback();
+  ConferenceClientConfiguration configuration_;
   std::shared_ptr<ConferenceSocketSignalingChannel> signaling_channel_;
   ConferenceWebTransportChannelObserver* observer_;
   bool connected_;

--- a/talk/owt/sdk/include/cpp/owt/base/commontypes.h
+++ b/talk/owt/sdk/include/cpp/owt/base/commontypes.h
@@ -157,18 +157,57 @@ enum class VideoSourceInfo : int {
   kMixed,       ///< From MCU mix engine
   kUnknown
 };
+#ifdef OWT_ENABLE_QUIC
+/// Data source info.
+/// This enumeration defines possible video sources.
+enum class DataSourceInfo : int {
+  kCamera = 1,  ///< Camera
+  kScreenCast,  ///< Screen-cast
+  kFile,        ///< From file
+  kUnknown
+};
+/// TransportType
+enum class TransportType : int {
+  kWebRTC = 1,
+  kWebTransport,
+  kUnknown = 99
+};
+/// TransportContraints
+struct TransportConstraints {
+  explicit TransportConstraints()
+      : type(TransportType::kWebRTC) {}
+
+  TransportType type;
+};
+#endif
 /// Stream source.
 struct StreamSourceInfo {
   explicit StreamSourceInfo()
     : audio(AudioSourceInfo::kUnknown),
-      video(VideoSourceInfo::kUnknown) {}
-  StreamSourceInfo(AudioSourceInfo audio_source, VideoSourceInfo video_source)
+      video(VideoSourceInfo::kUnknown)
+#ifdef OWT_ENABLE_QUIC
+      ,data(DataSourceInfo::kUnknown)
+#endif
+  {}
+  StreamSourceInfo(AudioSourceInfo audio_source, VideoSourceInfo video_source
+#ifdef OWT_ENABLE_QUIC
+  , DataSourceInfo data_source
+#endif
+  )
     : audio(audio_source),
-      video(video_source) {}
+      video(video_source)
+#ifdef OWT_ENABLE_QUIC
+      ,data(data_source)
+#endif
+  {}
   /// The audio source info of the stream
   AudioSourceInfo audio;
   /// The video source info of the stream
   VideoSourceInfo video;
+#ifdef OWT_ENABLE_QUIC
+  /// The data source info of the stream
+  DataSourceInfo data;
+#endif
 };
 struct EnumClassHash {
   template <typename T>

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -19,7 +19,7 @@
 namespace owt {
 namespace base{
 #ifdef OWT_ENABLE_QUIC
-typedef std::array<char, QUIC_CERT_FINGERPRINT_SIZE> cert_fingerprint_t;
+typedef std::string cert_fingerprint_t;
 #endif
 /** @cond */
 /// Audio processing settings.

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -13,13 +13,12 @@
 #include <array>
 #include <vector>
 #include "owt/quic/quic_transport_client_interface.h"
-#define QUIC_CERT_FINGERPRINT_SIZE 33
+#define QUIC_CERT_FINGERPRINT_SIZE 32
 #endif
 
 namespace owt {
 namespace base{
 #ifdef OWT_ENABLE_QUIC
-// certificate fingerprint must be null terminiated.
 typedef std::array<char, QUIC_CERT_FINGERPRINT_SIZE> cert_fingerprint_t;
 #endif
 /** @cond */

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -71,7 +71,9 @@ class GlobalConfiguration {
    @param fingerprints collection of trusted certificates' fingerprints.
   */
   static void SetTrustedQuicCertificateFingerprints(
-      const std::vector<cert_fingerprint_t>& fingerprints);
+      const std::vector<cert_fingerprint_t>& fingerprints) {
+    trusted_quic_certificate_fingerprints_ = fingerprints;
+  }
   /**
    @brief This function gets trusted certificate fingerprints
    @return the vector of trusted certificate fingerprints

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -9,18 +9,9 @@
 #if defined(WEBRTC_WIN)
 #include <windows.h>
 #endif
-#ifdef OWT_ENABLE_QUIC
-#include <array>
-#include <vector>
-#include "owt/quic/quic_transport_client_interface.h"
-#define QUIC_CERT_FINGERPRINT_SIZE 32
-#endif
 
 namespace owt {
 namespace base{
-#ifdef OWT_ENABLE_QUIC
-typedef std::string cert_fingerprint_t;
-#endif
 /** @cond */
 /// Audio processing settings.
 struct AudioProcessingSettings {
@@ -62,30 +53,6 @@ class GlobalConfiguration {
   static void SetVideoHardwareAccelerationEnabled(bool enabled) {
     hardware_acceleration_enabled_ = enabled;
   }
-#endif
-#ifdef OWT_ENABLE_QUIC
-  /**
-   @brief This function sets trusted server certificate fingerprints for
-   QUIC connections. If fingerprints is empty, will use webpki for certificate
-   verification. Fingerprint should be a string of format "xx:xx:xx..." which
-   contains SHA-256 of the certificate fingerprint. See more details of the MCU
-   document for getting this value.
-   @param fingerprints collection of trusted certificates' fingerprints.
-  */
-  static void SetTrustedQuicCertificateFingerprints(
-      const std::vector<cert_fingerprint_t>& fingerprints) {
-    trusted_quic_certificate_fingerprints_ = fingerprints;
-  }
-  /** @cond */
-  /**
-   @brief This function gets trusted certificate fingerprints
-   @return the vector of trusted certificate fingerprints
-  */
-  static std::vector<cert_fingerprint_t>
-  GetTrustedQuicCertificateFingerPrints() {
-    return trusted_quic_certificate_fingerprints_;
-  }
-  /** @endcod */
 #endif
   /** @cond */
   /**
@@ -209,9 +176,6 @@ class GlobalConfiguration {
   static bool GetCustomizedAudioInputEnabled() {
     return audio_frame_generator_ ? true : false;
   }
-#ifdef OWT_ENABLE_QUIC
-  static std::vector<cert_fingerprint_t> trusted_quic_certificate_fingerprints_;
-#endif
   /**
    @brief This function gets whether auto echo cancellation is enabled or not.
    @return true or false.

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -67,13 +67,16 @@ class GlobalConfiguration {
   /**
    @brief This function sets trusted server certificate fingerprints for
    QUIC connections. If fingerprints is empty, will use webpki for certificate
-   verification.
+   verification. Fingerprint should be a string of format "xx:xx:xx..." which
+   contains SHA-256 of the certificate fingerprint. See more details of the MCU
+   document for getting this value.
    @param fingerprints collection of trusted certificates' fingerprints.
   */
   static void SetTrustedQuicCertificateFingerprints(
       const std::vector<cert_fingerprint_t>& fingerprints) {
     trusted_quic_certificate_fingerprints_ = fingerprints;
   }
+  /** @cond */
   /**
    @brief This function gets trusted certificate fingerprints
    @return the vector of trusted certificate fingerprints
@@ -82,6 +85,7 @@ class GlobalConfiguration {
   GetTrustedQuicCertificateFingerPrints() {
     return trusted_quic_certificate_fingerprints_;
   }
+  /** @endcod */
 #endif
   /** @cond */
   /**

--- a/talk/owt/sdk/include/cpp/owt/base/localcamerastreamparameters.h
+++ b/talk/owt/sdk/include/cpp/owt/base/localcamerastreamparameters.h
@@ -69,6 +69,33 @@ class LocalCameraStreamParameters final {
   bool video_enabled_;
   bool audio_enabled_;
 };
+
+
+#ifdef OWT_ENABLE_QUIC
+/**
+  @brief This class contains parameters and methods needed for creating
+  a data stream for publishing to MCU.
+  Currently this only contains an |data_enabled_| field but may be extended
+  later to support more settings.
+ */
+class LocalDataStreamParameters final {
+ public:
+  LocalDataStreamParameters(bool data_enabled) {
+    data_enabled_ = data_enabled;
+  }
+  ~LocalDataStreamParameters() {}
+
+  /** @cond */
+  bool DataEnabled() const {
+    return data_enabled_;
+  }
+  /** @endcond */
+
+ private:
+  bool data_enabled_ = true;
+};
+#endif
+
 /**
   @brief This class contains parameters and methods that needed for creating a
   local customized stream.

--- a/talk/owt/sdk/include/cpp/owt/base/options.h
+++ b/talk/owt/sdk/include/cpp/owt/base/options.h
@@ -40,9 +40,20 @@ struct VideoPublicationSettings {
   unsigned long keyframe_interval;
   std::string rid;
 };
+
+#ifdef OWT_ENABLE_QUIC
+struct TransportSettings {
+  explicit TransportSettings() : transport_type(TransportType::kWebRTC) {}
+  TransportType transport_type;
+};
+#endif
+
 struct PublicationSettings {
   std::vector<AudioPublicationSettings> audio;
   std::vector<VideoPublicationSettings> video;
+#ifdef OWT_ENABLE_QUIC
+  TransportSettings transport;
+#endif
 };
 /**
  @brief Publish options describing encoding settings.
@@ -51,6 +62,9 @@ struct PublicationSettings {
 struct PublishOptions {
   std::vector<AudioEncodingParameters> audio;
   std::vector<VideoEncodingParameters> video;
+#ifdef OWT_ENABLE_QUIC
+  TransportConstraints transport;
+#endif
 };
 
 }  // namespace base

--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -198,11 +198,16 @@ class QuicStream : public owt::quic::QuicTransportStreamInterface::Visitor {
     can_read_ = false;
     can_write_ = false;
   }
+  void SetVisitor(owt::quic::QuicTransportStreamInterface::Visitor* visitor) {
+    if (quic_stream_ && visitor) {
+      quic_stream_->SetVisitor(visitor);
+    }
+  }
  private:
   owt::quic::QuicTransportStreamInterface* quic_stream_;
   std::string session_id_;
-  std::atomic<bool> can_read_ = false;
-  std::atomic<bool> can_write_ = false;
+  std::atomic<bool> can_read_ = true;
+  std::atomic<bool> can_write_ = true;
   std::atomic<bool> fin_read_ = false;
 };
 #endif // OWT_ENABLE_QUIC

--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -175,8 +175,8 @@ class Stream {
 
 #ifdef OWT_ENABLE_QUIC
 /// A QuicStream can be fetched from a published LocalStream for data,
-/// on which you can write to MCU;
-/// Or from a subscription from MCU for data, on which you can read.
+/// on which you can write to server;
+/// Or from a subscription from server for data, on which you can read.
 class QuicStream : public owt::quic::QuicTransportStreamInterface::Visitor {
  public:
   QuicStream(owt::quic::QuicTransportStreamInterface* quic_stream,
@@ -184,21 +184,21 @@ class QuicStream : public owt::quic::QuicTransportStreamInterface::Visitor {
   ~QuicStream();
 
   /**
-   @brief Write data to MCU.
-   @details Send data to MCU with WebTransport. Should be only
+   @brief Write data to server.
+   @details Send data to server with WebTransport. Should be only
    called when stream is published.
-   @param data Pointer to data to be written to MCU
+   @param data Pointer to data to be written to server
    @param length Size of data to be written.
-   @param Actual bytes written to MCU.
+   @param Actual bytes written to server.
   */
   size_t Write(uint8_t* data, size_t length);
   /**
-   @brief Read data from MCU.
-   @details Read data from MCU with WebTransport. Should only
+   @brief Read data from server.
+   @details Read data from server with WebTransport. Should only
    be called on stream returned from subscription.
    @param data Pointer to the buffer from storing data.
    @param length Size of the buffer.
-   @return Size of data actually read from MCU.
+   @return Size of data actually read from server.
   */
   size_t Read(uint8_t* data, size_t length);
   /**
@@ -291,13 +291,13 @@ class LocalStream : public Stream {
 
 #ifdef OWT_ENABLE_QUIC
   /**
-   @brief Create a data stream for writing data to MCU.
+   @brief Create a data stream for writing data to server.
    @detail This creates a WebTransport stream for publishing data.
    @param error_code Error code will be set if creation fails.
    @return Pointer to created LocalStream.
   */
   static std::shared_ptr<LocalStream> Create(
-      std::shared_ptr<QuicStream> writable_stream,
+      std::shared_ptr<QuicStream> quic_stream,
       int& error_code);
 
   /**
@@ -407,7 +407,7 @@ class LocalStream : public Stream {
 };
 /**
   @brief This class represents a remote stream.
-  @details A remote is published from a remote client or MCU. Do not construct
+  @details A remote is published from a remote client or server. Do not construct
   remote stream outside SDK.
 */
 class RemoteStream : public Stream {

--- a/talk/owt/sdk/include/cpp/owt/base/subscription.h
+++ b/talk/owt/sdk/include/cpp/owt/base/subscription.h
@@ -5,6 +5,9 @@
 #define OWT_BASE_SUBSCRIPTION_H_
 #include "owt/base/commontypes.h"
 #include "owt/base/mediaconstraints.h"
+#ifdef OWT_ENABLE_QUIC
+#include "owt/quic/quic_transport_stream_interface.h"
+#endif
 namespace owt {
 namespace base {
 /// Observer that receives events from subscription.
@@ -18,6 +21,11 @@ class SubscriptionObserver {
     virtual void OnUnmute(TrackKind track_kind) = 0;
     /// Triggered when error happens with subscription.
     virtual void OnError(std::unique_ptr<owt::base::Exception> error) = 0;
+#ifdef OWT_ENABLE_QUIC
+    /// Triggered when QuicStream assoicated with the subscription
+    /// is ready for reading.
+    virtual void OnReady() = 0;
+#endif
 };
 } // namespace base
 } // namespace owt

--- a/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
@@ -21,7 +21,9 @@
 #include "owt/conference/conferencesubscription.h"
 #include "owt/conference/streamupdateobserver.h"
 #include "owt/conference/subscribeoptions.h"
-
+#ifdef OWT_ENABLE_QUIC
+#include "owt/quic/quic_transport_stream_interface.h"
+#endif
 namespace sio{
   class message;
 }
@@ -520,6 +522,9 @@ class ConferenceClient final
   // key is session_id(subscription_id)
   std::map<std::string, std::shared_ptr<ConferenceSubscription>> quic_subscriptions_;
   mutable std::mutex quic_subscriptions_mutex_;
+  std::unordered_map<std::string, QuicTransportStreamInterface*>
+      pending_incoming_streams_;
+  mutable std::mutex pending_quic_streams_mutex_;
 #endif
 };
 }

--- a/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
@@ -39,16 +39,30 @@ namespace owt {
 namespace conference {
 class Participant;
 using namespace owt::base;
+
 #ifdef OWT_ENABLE_QUIC
 using namespace owt::quic;
+typedef std::string cert_fingerprint_t;
 #endif
+
 /**
   @brief Configuration for creating a ConferenceClient
   @details This configuration is used while creating ConferenceClient.
   Changing this configuration does NOT impact ConferenceClient already
   created.
 */
-struct ConferenceClientConfiguration : ClientConfiguration {};
+struct ConferenceClientConfiguration : public ClientConfiguration {
+#ifdef OWT_ENABLE_QUIC
+ public:
+  // This function sets trusted server certificate fingerprints for
+  // QUIC connections. If fingerprints is empty, will use webpki for certificate
+  // verification. Fingerprint should be a string of format "xx:xx:xx..." which
+  // contains SHA-256 of the certificate fingerprint. See more details of the MCU
+  // document for getting this value.
+  std::vector<cert_fingerprint_t> trusted_quic_certificate_fingerprints;
+#endif
+};
+
 class RemoteMixedStream;
 class ConferencePeerConnectionChannel;
 #ifdef OWT_ENABLE_QUIC

--- a/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
@@ -332,7 +332,10 @@ class ConferenceClient final
 #ifdef OWT_ENABLE_QUIC
   /**
    @brief Creates a LocalStream for WebTransport.
-    Please be noted this can only be called when client is connected to MCU(successfully joined).
+   @details Please be noted this can only be called when
+   client is connected to MCU(successfully joined).
+   @param onSuccess Success callback with a LocalStream on which
+   you can get a QuicStream.
   */
   void CreateSendStream(
       std::function<void(std::shared_ptr<owt::base::LocalStream>)> on_success,

--- a/talk/owt/sdk/include/cpp/owt/conference/conferencepublication.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferencepublication.h
@@ -69,6 +69,9 @@ class ConferencePublication : public Publication, public ConferenceStreamUpdateO
     std::vector<std::reference_wrapper<PublicationObserver>> observers_;
     std::weak_ptr<ConferenceClient> conference_client_;   // Weak ref to associated conference client
     std::shared_ptr<rtc::TaskQueue> event_queue_;
+#ifdef OWT_ENABLE_QUIC
+    std::shared_ptr<owt::base::QuicStream> writable_stream_;
+#endif
 };
 } // namespace conference
 } // namespace owt

--- a/talk/owt/sdk/include/cpp/owt/conference/conferencesubscription.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferencesubscription.h
@@ -13,6 +13,7 @@
 #include "owt/base/exception.h"
 #include "owt/conference/streamupdateobserver.h"
 #include "owt/conference/subscribeoptions.h"
+
 namespace rtc {
   class TaskQueue;
 }
@@ -20,6 +21,11 @@ namespace webrtc{
   class StatsReport;
 }
 namespace owt {
+namespace quic {
+class QuicTransportStreamInterface;
+}
+}
+  namespace owt {
 namespace conference {
 class ConferenceClient;
 using namespace owt::base;
@@ -55,6 +61,9 @@ class ConferenceSubscription : public ConferenceStreamUpdateObserver,
     bool Ended() { return ended_; }
     /// Get the subscription ID
     std::string Id() const { return id_; }
+#ifdef OWT_ENABLE_QUIC
+    std::shared_ptr<owt::base::QuicStream> Stream();
+#endif
     /// Update the subscription with new encoding settings.
     void ApplyOptions(
         const SubscriptionUpdateOptions& options,
@@ -68,6 +77,9 @@ class ConferenceSubscription : public ConferenceStreamUpdateObserver,
     void OnStreamMuteOrUnmute(const std::string& stream_id, TrackKind track_kind, bool muted);
     void OnStreamRemoved(const std::string& stream_id);
     void OnStreamError(const std::string& error_msg);
+#ifdef OWT_ENABLE_QUIC
+    void OnIncomingStream(const std::string& session_id, owt::quic::QuicTransportStreamInterface* stream);
+#endif
     std::string id_;
     std::string stream_id_;
     bool ended_;
@@ -75,6 +87,9 @@ class ConferenceSubscription : public ConferenceStreamUpdateObserver,
     std::vector<std::reference_wrapper<SubscriptionObserver>> observers_;
     std::weak_ptr<ConferenceClient>  conference_client_;   // Weak ref to associated conference client
     std::shared_ptr<rtc::TaskQueue> event_queue_;
+#ifdef OWT_ENABLE_QUIC
+    std::shared_ptr<owt::base::QuicStream> quic_stream_;
+#endif
 };
 
 } // namespace conference

--- a/talk/owt/sdk/include/cpp/owt/conference/streamupdateobserver.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/streamupdateobserver.h
@@ -4,6 +4,9 @@
 #ifndef OWT_CONFERENCE_STREAMUPDATEOBSERVER_H
 #define OWT_CONFERENCE_STREAMUPDATEOBSERVER_H
 #include "owt/base/commontypes.h"
+#ifdef OWT_ENABLE_QUIC
+#include "owt/quic/quic_transport_stream_interface.h"
+#endif
 namespace owt {
 namespace conference {
 /** @cond */
@@ -17,6 +20,10 @@ public:
     owt::base::TrackKind track_kind, bool muted) {}
   virtual void OnStreamRemoved(const std::string& stream_id) {}
   virtual void OnStreamError(const std::string& error_msg){}
+#ifdef OWT_ENABLE_QUIC
+  virtual void OnIncomingStream(
+      const std::string& session_id, owt::quic::QuicTransportStreamInterface* stream) {}
+#endif
 };
 /** @endcond */
 }

--- a/talk/owt/sdk/include/cpp/owt/conference/subscribeoptions.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/subscribeoptions.h
@@ -40,10 +40,22 @@ struct VideoSubscriptionConstraints {
   unsigned long keyFrameInterval;
   std::string rid;
 };
+
+#ifdef OWT_ENABLE_QUIC
+/// Data subscription constraints.
+struct DataSubscriptionConstraints {
+  explicit DataSubscriptionConstraints() : enabled(false) {}
+  bool enabled;
+};
+#endif
+
 /// Subscribe options
 struct SubscribeOptions {
   AudioSubscriptionConstraints audio;
   VideoSubscriptionConstraints video;
+#ifdef OWT_ENABLE_QUIC
+  DataSubscriptionConstraints data;
+#endif
 };
 /// Video subscription update constrains used by subscription's ApplyOptions
 /// API.


### PR DESCRIPTION
@jianjunz @HuaChunbo PTAL 
this enables the quic transport for MCU that supports it. By default the SDK is not built with quic support. If in gn args owt_use_quic is set to true and owt_quic_header_root is specified, the conference SDK will have quic support.