### PR TITLE
Use track id for simulcast stream subscription.

### DIFF
--- a/talk/owt/sdk/conference/conferenceclient.cc
+++ b/talk/owt/sdk/conference/conferenceclient.cc
@@ -1487,10 +1487,15 @@ void ConferenceClient::ParseStreamInfo(sio::message::ptr stream_info,
                   keyframe_interval_num;
             }
           }
-          auto rid_obj = (*tit)->get_map()["simulcastRid"];
+          auto rid_obj = (*tit)->get_map()["rid"];
           if (rid_obj != nullptr &&
               rid_obj->get_flag() == sio::message::flag_string) {
             video_publication_settings.rid = rid_obj->get_string();
+          }
+          auto trackid_obj = (*tit)->get_map()["id"];
+          if (trackid_obj != nullptr &&
+              trackid_obj->get_flag() == sio::message::flag_string) {
+            video_publication_settings.track_id = trackid_obj->get_string();
           }
           publication_settings.video.push_back(video_publication_settings);
         }

--- a/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
+++ b/talk/owt/sdk/conference/conferencepeerconnectionchannel.cc
@@ -633,8 +633,20 @@ void ConferencePeerConnectionChannel::Subscribe(
     } else {
       video_options->get_map()["mid"] = sio::string_message::create("1");
     }
-    video_options->get_map()["from"] =
-        sio::string_message::create(stream->Id());
+    auto publication_settings = stream->Settings();
+    if (subscribe_options.video.rid != "") {
+      for (auto video_setting : publication_settings.video) {
+        if (video_setting.rid == subscribe_options.video.rid) {
+          std::string track_id = video_setting.track_id;
+          video_options->get_map()["from"] =
+              sio::string_message::create(track_id);
+          break;
+        }
+      }
+    } else {
+      video_options->get_map()["from"] =
+          sio::string_message::create(stream->Id());
+    }
     sio::message::ptr video_spec = sio::object_message::create();
     sio::message::ptr resolution_options = sio::object_message::create();
     if (subscribe_options.video.resolution.width != 0 &&

--- a/talk/owt/sdk/include/cpp/owt/base/options.h
+++ b/talk/owt/sdk/include/cpp/owt/base/options.h
@@ -39,6 +39,7 @@ struct VideoPublicationSettings {
   unsigned long bitrate;
   unsigned long keyframe_interval;
   std::string rid;
+  std::string track_id;
 };
 
 #ifdef OWT_ENABLE_QUIC


### PR DESCRIPTION
v1.2 signaling protocol requires using track_id for subscribing simulcast stream. Each remote stream will have a single stream id but multiple track_id, one for each simulcast ssrc. 