### PR TITLE
Implement media foundation based video capturer.

### DIFF
--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -117,6 +117,7 @@ static_library("owt_sdk_base") {
     "sdk/base/vcmcapturer.h",
     "sdk/base/webrtcaudiorendererimpl.cc",
     "sdk/base/webrtcaudiorendererimpl.h",
+    "sdk/base/windowcapturer.cc",
     "sdk/include/cpp/owt/base/audioplayerinterface.h",
     "sdk/include/cpp/owt/base/clientconfiguration.h",
     "sdk/include/cpp/owt/base/connectionstats.h",
@@ -242,7 +243,11 @@ static_library("owt_sdk_base") {
       "sdk/base/win/videorendererd3d11.h",
       "sdk/base/win/vp9ratecontrol.cc",
       "sdk/base/win/vp9ratecontrol.h",
-      "sdk/base/windowcapturer.cc",
+      "sdk/base/win/d3d11_manager.h",
+      "sdk/base/win/device_info_mf.h",
+      "sdk/base/win/device_info_mf.cc",
+      "sdk/base/win/video_capture_mf.h",
+      "sdk/base/win/video_capture_mf.cc",
     ]
     public_deps += [ "//third_party/webrtc/modules/audio_device:audio_device_module_from_input_and_output" ]
     public_deps += [ "//third_party/libvpx" ]

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -117,7 +117,6 @@ static_library("owt_sdk_base") {
     "sdk/base/vcmcapturer.h",
     "sdk/base/webrtcaudiorendererimpl.cc",
     "sdk/base/webrtcaudiorendererimpl.h",
-    "sdk/base/windowcapturer.cc",
     "sdk/include/cpp/owt/base/audioplayerinterface.h",
     "sdk/include/cpp/owt/base/clientconfiguration.h",
     "sdk/include/cpp/owt/base/connectionstats.h",
@@ -141,6 +140,7 @@ static_library("owt_sdk_base") {
       "sdk/base/encodedvideoencoderfactory.h",
       "sdk/base/webrtcvideorendererimpl.cc",
       "sdk/base/webrtcvideorendererimpl.h",
+      "sdk/base/windowcapturer.cc",
       "sdk/include/cpp/owt/base/videodecoderinterface.h",
     ]
   }

--- a/talk/owt/sdk/base/win/d3d11_manager.h
+++ b/talk/owt/sdk/base/win/d3d11_manager.h
@@ -1,0 +1,116 @@
+// Copyright (C) <2021> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OWT_BASE_WIN_D3D11_MANAGER_H
+#define OWT_BASE_WIN_D3D11_MANAGER_H
+
+#include <atlbase.h>
+#include <dxgi1_2.h>
+#include <d3d11_2.h>
+#include <mfobjects.h>
+#include <mfapi.h>
+#include "webrtc/rtc_base/logging.h"
+#include "webrtc/rtc_base/ref_count.h"
+
+namespace owt {
+namespace base {
+
+class D3D11Manager : public rtc::RefCountInterface {
+ public:
+  D3D11Manager()
+      : manager_(nullptr),
+        device_(nullptr),
+        ctx_(nullptr),
+        adapter_(nullptr),
+        mt_(nullptr),
+        reset_token_(0) {}
+
+  ~D3D11Manager() = default;
+
+  bool Init() {
+    HRESULT hr = MFCreateDXGIDeviceManager(&reset_token_, &manager_);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "MFCreateDxgiDeviceManager failed with error hr:"
+                        << hr;
+      return false;
+    }
+
+    CComPtr<IDXGIFactory2> factory;
+    hr = CreateDXGIFactory1(__uuidof(IDXGIFactory2), (void**)(&factory));
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "CreateDxgiFactory failed with error hr:" << hr;
+      return false;
+    }
+
+    hr = factory->EnumAdapters(0, &adapter_);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "EnumAdapters failed with error hr:" << hr;
+      return false;
+    }
+
+    UINT creation_flags = D3D11_CREATE_DEVICE_VIDEO_SUPPORT | D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+
+    D3D_FEATURE_LEVEL feature_levels_in[] = {
+        D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1,
+        D3D_FEATURE_LEVEL_10_0};
+
+    D3D_FEATURE_LEVEL feature_levels_out;
+    hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr,
+                           creation_flags, feature_levels_in,
+                           ARRAYSIZE(feature_levels_in), D3D11_SDK_VERSION,
+                           &device_, &feature_levels_out, &ctx_);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "D3D11 CreateDevice failed with error hr:" << hr;
+      return false;
+    }
+
+    hr = manager_->ResetDevice(device_, reset_token_);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "ResetDevice failed with error hr:" << hr;
+      return false;
+    }
+
+    hr = device_->QueryInterface(__uuidof(ID3D10Multithread), (void**)(&mt_));
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "CreateDxgiFactory failed with error hr:" << hr;
+      return false;
+    }
+
+    hr = mt_->SetMultithreadProtected(true);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "SetMultithread Protection failed with error hr:"
+                        << hr;
+      return false;
+    }
+
+    return true;
+  }
+
+  CComPtr<IMFDXGIDeviceManager> GetManager() {
+      return manager_;
+  }
+
+  CComPtr<ID3D11Device> GetDevice() {
+      return device_;
+  }
+
+  CComPtr<ID3D11DeviceContext> GetDeviceContext() {
+      return ctx_;
+  }
+
+  CComPtr<ID3D10Multithread> GetMultiThread() {
+      return mt_;
+  }
+
+ private:
+  CComPtr<IMFDXGIDeviceManager> manager_;
+  CComPtr<ID3D11Device> device_;
+  CComPtr<ID3D11DeviceContext> ctx_;
+  CComQIPtr<IDXGIAdapter> adapter_;
+  CComPtr<ID3D10Multithread> mt_;
+  UINT reset_token_;
+};
+}  // namespace base
+}  // namespace owt
+#endif //OWT_BASE_WIN_D3D11_MANAGER_H

--- a/talk/owt/sdk/base/win/device_info_mf.cc
+++ b/talk/owt/sdk/base/win/device_info_mf.cc
@@ -31,7 +31,7 @@ DeviceInfoMF* DeviceInfoMF::Create() {
 
 DeviceInfoMF::DeviceInfoMF() {
   // Maybe we should move this to Init().
-  HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+  HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
   if (FAILED(hr)) {
     if (hr == RPC_E_CHANGED_MODE) {
       RTC_LOG(LS_WARNING)

--- a/talk/owt/sdk/base/win/device_info_mf.cc
+++ b/talk/owt/sdk/base/win/device_info_mf.cc
@@ -1,0 +1,367 @@
+// Copyright (C) <2021> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "talk/owt/sdk/base/win/device_info_mf.h"
+
+#include <atlbase.h>
+#include <atlcom.h>
+#include <system_error>
+#include "absl/strings/match.h"
+#include "webrtc/api/scoped_refptr.h"
+#include "webrtc/rtc_base/logging.h"
+#include "webrtc/rtc_base/string_utils.h"
+
+#pragma comment(lib, "Mfuuid.lib")
+#pragma comment(lib, "Mfplat.lib")
+#pragma comment(lib, "Mfreadwrite.lib")
+#pragma comment(lib, "Mf.lib")
+
+namespace webrtc {
+namespace videocapturemodule {
+
+DeviceInfoMF* DeviceInfoMF::Create() {
+  DeviceInfoMF* ds_info = new (std::nothrow) DeviceInfoMF();
+  if (!ds_info || ds_info->Init() != 0) {
+    delete ds_info;
+    ds_info = nullptr;
+  }
+  return ds_info;
+}
+
+DeviceInfoMF::DeviceInfoMF() {
+  // Maybe we should move this to Init().
+  HRESULT hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+  if (FAILED(hr)) {
+    if (hr == RPC_E_CHANGED_MODE) {
+      RTC_LOG(LS_WARNING)
+          << "CoInitializeEx failed:" << std::system_category().message(hr);
+    }
+    return;
+  }
+}
+
+DeviceInfoMF::~DeviceInfoMF() {
+  MFShutdown();
+  CoUninitialize();
+}
+
+int32_t DeviceInfoMF::Init() {
+  HRESULT hr = MFStartup(MF_VERSION);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_WARNING) << "MFStartup failed:"
+                        << std::system_category().message(hr);
+    return -1;
+  }
+  return 0;
+}
+
+uint32_t DeviceInfoMF::NumberOfDevices() {
+  webrtc::MutexLock lock(&_apiLock);
+  return GetDeviceInfo(0, 0, 0, 0, 0, 0, 0);
+}
+
+int32_t DeviceInfoMF::GetDeviceName(uint32_t deviceNumber,
+                                  char* deviceNameUTF8,
+                                  uint32_t deviceNameLength,
+                                  char* deviceUniqueIdUTF8,
+                                  uint32_t deviceUniqueIdUTF8Length,
+                                  char* productUniqueIdUTF8,
+                                  uint32_t productUniqueIdUTF8Length) {
+  webrtc::MutexLock lock(&_apiLock);
+  const int32_t result =
+      GetDeviceInfo(deviceNumber, deviceNameUTF8, deviceNameLength,
+                    deviceUniqueIdUTF8, deviceUniqueIdUTF8Length,
+                    productUniqueIdUTF8, productUniqueIdUTF8Length);
+  return (result > (int32_t)deviceNumber) ? 0 : -1;
+}
+
+int32_t DeviceInfoMF::GetDeviceInfo(uint32_t deviceNumber,
+                                    char* deviceNameUTF8,
+                                    uint32_t deviceNameLength,
+                                    char* deviceUniqueIdUTF8,
+                                    uint32_t deviceUniqueIdUTF8Length,
+                                    char* productUniqueIdUTF8,
+                                    uint32_t productUniqueIdUTF8Length) {
+  CComPtr<IMFAttributes> attributes = nullptr;
+  CComHeapPtr<IMFActivate*> devices;
+  int32_t num_devices = -1;
+  uint32_t source_count = 0;
+
+  HRESULT hr = MFCreateAttributes(&attributes, 1);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "MFCreateAttributes failed:"
+                      << std::system_category().message(hr);
+    return num_devices;
+  }
+
+  // Request the video capture devices by setting GUID
+  hr = attributes->SetGUID(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
+                            MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetGUID failed:"
+                      << std::system_category().message(hr);
+    return num_devices;
+  }
+
+  // Enumerate the devices
+  hr = MFEnumDeviceSources(attributes, &devices, &source_count);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "MFEnumDeviceSources failed:"
+                      << std::system_category().message(hr);
+    return num_devices;
+  }
+
+  for (uint32_t idx = 0; idx < source_count; idx++) {
+    if (deviceNumber == idx) {
+      // Found a valid device
+      int ret = 0;
+      CComHeapPtr<WCHAR> device_name;
+      hr = devices[idx]->GetAllocatedString(
+          MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, &device_name, nullptr);
+      if (FAILED(hr)) {
+        RTC_LOG(LS_ERROR) << "Getting device friendly name failed:"
+                          << std::system_category().message(hr);
+      }
+      else if (deviceNameLength > 0) {
+        ret = WideCharToMultiByte(CP_UTF8, 0, device_name, -1,
+                                         (char*)deviceNameUTF8,
+                                         deviceNameLength, nullptr, nullptr);
+        if (!ret) {
+          RTC_LOG(LS_ERROR) << "Failed to convert device name to UTF8, error = "
+              << GetLastError();
+          break;
+        }
+      }
+
+      CComHeapPtr<WCHAR> device_unique_name;
+      hr = devices[idx]->GetAllocatedString(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK,
+          &device_unique_name, nullptr);
+      if (FAILED(hr)) {
+        RTC_LOG(LS_ERROR) << "Getting device friendly name failed:"
+                          << std::system_category().message(hr);
+      }
+      else if (deviceUniqueIdUTF8Length > 0) {
+        ret = WideCharToMultiByte(CP_UTF8, 0, device_unique_name, -1,
+                                         (char*)deviceUniqueIdUTF8,
+                                         deviceUniqueIdUTF8Length, nullptr, nullptr);
+        if (!ret) {
+          RTC_LOG(LS_ERROR) << "Failed to convert device name to UTF8, error = "
+              << GetLastError();
+          break;
+        }
+      }
+      num_devices = source_count;
+      break;
+    }
+  }
+
+  for (uint32_t i = 0; i < source_count; i++) {
+    SAFE_RELEASE(devices[i]);
+  }
+
+  return num_devices;
+}
+
+int32_t DeviceInfoMF::DisplayCaptureSettingsDialogBox(
+    const char* deviceUniqueIdUTF8,
+    const char* dialogTitleUTF8,
+    void* parentWindow,
+    uint32_t positionX,
+    uint32_t positionY) {
+  return -1;
+}
+
+IMFMediaSource* DeviceInfoMF::GetCaptureSource(const char*& deviceUniqueIdUTF8) {
+  CComPtr<IMFAttributes> attributes = nullptr;
+  IMFMediaSource* source = nullptr;
+  std::wstring deviceUniqueName(deviceUniqueIdUTF8,
+      deviceUniqueIdUTF8 + strlen(deviceUniqueIdUTF8));
+
+  // Max Count will be kVideoCaptureUniqueNameLength(Max UniqueName length)
+  if (deviceUniqueName.length() > kVideoCaptureUniqueNameLength) {
+    RTC_LOG(LS_INFO) << "Device name too long";
+    return nullptr;
+  }
+
+  HRESULT hr = MFCreateAttributes(&attributes, 1);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "MFCreateAttributes failed:"
+                      << std::system_category().message(hr);
+    return nullptr;
+  }
+
+  // Request the vidoe capture device by setting GUID
+  hr = attributes->SetGUID(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
+                            MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetGUID failed:"
+                      << std::system_category().message(hr);
+    return nullptr;
+  }
+
+  hr = attributes->SetString(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK,
+      deviceUniqueName.c_str());
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetUniqueName failed:"
+                      << std::system_category().message(hr);
+    return nullptr;
+  }
+
+  hr = MFCreateDeviceSource(attributes, &source);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "MFCreateDeviceSource failed:"
+                      << std::system_category().message(hr);
+  }
+
+  return source;
+}
+
+int32_t DeviceInfoMF::CreateCapabilityMap(const char* deviceUniqueIdUTF8) {
+  // Reset old capability list
+  _captureCapabilities.clear();
+
+  const int32_t deviceUniqueIdUTF8Length =
+      (int32_t)strnlen_s((char*)deviceUniqueIdUTF8, kVideoCaptureUniqueNameLength);
+  if (deviceUniqueIdUTF8Length > kVideoCaptureUniqueNameLength) {
+    RTC_LOG(LS_INFO) << "Device name too long";
+    return -1;
+  }
+
+  CComPtr<IMFMediaSource> source(GetCaptureSource(deviceUniqueIdUTF8));
+  if (source == nullptr) {
+    RTC_LOG(LS_ERROR) << "Unable to create capture source.";
+    return -1;
+  }
+
+  CComPtr<IMFPresentationDescriptor> pd = nullptr;
+  CComPtr<IMFStreamDescriptor> sd = nullptr;
+  CComPtr<IMFMediaTypeHandler> mh = nullptr;
+  IMFMediaType* media_type = nullptr;
+  DWORD num_formats = 0;
+
+  // Get the presentation descriptor
+  HRESULT hr = source->CreatePresentationDescriptor(&pd);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "CreatePresentationDescriptor failed:"
+                      << std::system_category().message(hr);
+    return -1;
+  }
+
+  // Get the stream descriptor
+  BOOL selected = false;
+  hr = pd->GetStreamDescriptorByIndex(0/*video*/, &selected, &sd);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "GetVideoStreamDescriptor failed:"
+                      << std::system_category().message(hr);
+    return -1;
+  }
+
+  hr = sd->GetMediaTypeHandler(&mh);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "GetMediaTypeHandler failed:"
+                      << std::system_category().message(hr);
+    return -1;
+  }
+
+  hr = mh->GetMediaTypeCount(&num_formats);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "GetMediaTypeCount failed:"
+                      << std::system_category().message(hr);
+    return -1;
+  }
+
+  RTC_LOG(LS_INFO) << "Total number of formats supported are " << num_formats;
+  for (DWORD idx = 0; idx < num_formats; idx++) {
+    // Releasing on entering the loop is because if in case there was any error
+    // inside the loop, helps to release the media_type for the next one.
+    SAFE_RELEASE(media_type);
+    // Get MediaType at Index
+    hr = mh->GetMediaTypeByIndex(idx, &media_type);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "GetMediaType at index " << idx
+                        << " failed:" << std::system_category().message(hr);
+      continue;
+    }
+    VideoCaptureCapability capability;
+    capability.interlaced = false;
+
+    // Get the frame width and height
+    hr = MFGetAttributeSize(media_type, MF_MT_FRAME_SIZE,
+                            (UINT32*)&capability.width,
+                            (UINT32*)&capability.height);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "GetFrameSize failed:"
+                        << std::system_category().message(hr);
+      continue;
+    }
+
+    UINT32 frame_rate = 0, denominator = 0;
+    // Get the frame rate that is supported
+    hr = MFGetAttributeRatio(media_type, MF_MT_FRAME_RATE, &frame_rate,
+                             &denominator);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "VideoCatpurer: GetFrameRate failed:"
+                        << std::system_category().message(hr);
+      continue;
+    }
+    frame_rate = (denominator != 0) ? frame_rate / denominator : frame_rate;
+    capability.maxFPS = frame_rate;
+
+    GUID sub_type = { 0 };
+    // Get the video subtype for this media.
+    hr = media_type->GetGUID(MF_MT_SUBTYPE, &sub_type);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "GetMediaSubTypeGUID failed:"
+                        << std::system_category().message(hr);
+      continue;
+    }
+
+    // Cannot switch media type.
+    if (sub_type == MFVideoFormat_I420) {
+      capability.videoType = VideoType::kI420;
+    } else if (sub_type == MFVideoFormat_IYUV) {
+      capability.videoType = VideoType::kIYUV;
+    } else if (sub_type == MFVideoFormat_RGB24) {
+      capability.videoType = VideoType::kRGB24;
+    } else if (sub_type == MFVideoFormat_YUY2) {
+      capability.videoType = VideoType::kYUY2;
+    } else if (sub_type == MFVideoFormat_NV12) {
+      capability.videoType = VideoType::kNV12;
+    } else if (sub_type == MFVideoFormat_RGB565) {
+      capability.videoType = VideoType::kRGB565;
+    } else if (sub_type == MFVideoFormat_MJPG) {
+      capability.videoType = VideoType::kMJPEG;
+    } else if (sub_type == MFVideoFormat_UYVY) {
+      capability.videoType = VideoType::kUYVY;
+    } else {
+      WCHAR str_guid[32];
+      StringFromGUID2(sub_type, str_guid, 32);
+      RTC_LOG(LS_WARNING) << "Device support unknown media type " << str_guid
+                          << ", width " << capability.width << ", height "
+                          << capability.height;
+      continue;
+    }
+    _captureCapabilities.push_back(capability);
+    RTC_LOG(LS_INFO) << "Camera capability, width:" << capability.width
+                     << " height:" << capability.height
+                     << " type:" << static_cast<int>(capability.videoType)
+                     << " fps:" << capability.maxFPS;
+  }
+
+  if (SUCCEEDED(hr)) {
+    // Store the new used device name
+    _lastUsedDeviceNameLength = deviceUniqueIdUTF8Length;
+    _lastUsedDeviceName = (char*)realloc(_lastUsedDeviceName,
+        _lastUsedDeviceNameLength + 1);
+    if (_lastUsedDeviceName)
+      memcpy_s(_lastUsedDeviceName, _lastUsedDeviceNameLength + 1,
+          deviceUniqueIdUTF8, _lastUsedDeviceNameLength + 1);
+  }
+  // In case of any error in the loop
+  SAFE_RELEASE(media_type);
+
+  return SUCCEEDED(hr) ? 0 : -1;
+}
+} // namespace videocapturemodule
+} // namespace webrtc

--- a/talk/owt/sdk/base/win/device_info_mf.h
+++ b/talk/owt/sdk/base/win/device_info_mf.h
@@ -1,0 +1,78 @@
+// Copyright (C) <2021> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OWT_BASE_WIN_DEVICE_INFO_MF_H
+#define OWT_BASE_WIN_DEVICE_INFO_MF_H
+
+#include <mfapi.h>
+#include <mferror.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+#include <strsafe.h>
+#include <windows.h>
+#include "webrtc/modules/video_capture/device_info_impl.h"
+#include "webrtc/rtc_base/synchronization/mutex.h"
+#include "webrtc/rtc_base/thread_annotations.h"
+
+
+namespace webrtc {
+namespace videocapturemodule {
+
+#define SAFE_RELEASE(punknown) \
+  if ((punknown) != nullptr) {    \
+    (punknown)->Release();     \
+    (punknown) = nullptr;         \
+  }
+
+class DeviceInfoMF : public DeviceInfoImpl {
+public:
+  static DeviceInfoMF* Create();
+
+  DeviceInfoMF();
+  ~DeviceInfoMF() override;
+
+  int32_t Init() override;
+  uint32_t NumberOfDevices() override;
+
+  /*
+   * Returns the available capture devices.
+   */
+  int32_t GetDeviceName(uint32_t deviceNumber,
+                        char* deviceNameUTF8,
+                        uint32_t deviceNameLength,
+                        char* deviceUniqueIdUTF8,
+                        uint32_t deviceUniqueIdUTF8Length,
+                        char* productUniqueIdUTF8,
+                        uint32_t productUniqueIdUTF8Length) override;
+  /*
+   * Display OS /capture device specific settings dialog
+   */
+  int32_t DisplayCaptureSettingsDialogBox(const char* deviceUniqueIdUTF8,
+                                          const char* dialogTitleUTF8,
+                                          void* parentWindow,
+                                          uint32_t positionX,
+                                          uint32_t positionY) override;
+  /*
+   * Creates a Capture Device Media Source
+   * Responsible by the user to release the MediaSource
+   */
+  IMFMediaSource* GetCaptureSource(const char*& deviceUniqueIdUTF8);
+
+protected:
+  int32_t GetDeviceInfo(uint32_t deviceNumber,
+                        char* deviceNameUTF8,
+                        uint32_t deviceNameLength,
+                        char* deviceUniqueIdUTF8,
+                        uint32_t deviceUniqueIdUTF8Length,
+                        char* productUniqueIdUTF8,
+                        uint32_t productUniqueIdUTF8Length);
+
+  int32_t CreateCapabilityMap(const char* deviceUniqueIdUTF8) override
+      RTC_EXCLUSIVE_LOCKS_REQUIRED(_apiLock);
+  ;
+};
+
+}  // namespace videocapturemodule
+}  // namespace webrtc
+#endif  // OWT_BASE_WIN_DEVICE_INFO_MF_H

--- a/talk/owt/sdk/base/win/video_capture_mf.cc
+++ b/talk/owt/sdk/base/win/video_capture_mf.cc
@@ -1,0 +1,478 @@
+// Copyright (C) <2021> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "talk/owt/sdk/base/win/video_capture_mf.h"
+
+#include <atlbase.h>
+#include <atlcom.h>
+#include <system_error>
+#include "talk/owt/sdk/base/nativehandlebuffer.h"
+#include "third_party/libyuv/include/libyuv.h"
+#include "webrtc/api/scoped_refptr.h"
+#include "webrtc/api/video/i420_buffer.h"
+#include "webrtc/api/video/video_frame_buffer.h"
+#include "webrtc/api/video/nv12_buffer.h"
+#include "webrtc/common_video/libyuv/include/webrtc_libyuv.h"
+#include "webrtc/modules/video_capture/video_capture_config.h"
+#include "webrtc/rtc_base/ref_counted_object.h"
+#include "webrtc/rtc_base/logging.h"
+#include "webrtc/rtc_base/string_utils.h"
+#include "webrtc/rtc_base/time_utils.h"
+
+
+namespace webrtc {
+namespace videocapturemodule {
+
+std::unique_ptr<VideoCaptureMF> VideoCaptureMF::Create(
+      const char* device_id, int32_t width,
+      int32_t height, int32_t fps) {
+  if (device_id == nullptr) {
+    return nullptr;
+  }
+
+  std::unique_ptr<VideoCaptureMF> capturer;
+  capturer.reset(new VideoCaptureMF());
+  if (!capturer->Init(device_id, width, height, fps)) {
+    return nullptr;
+  }
+
+  return capturer;
+}
+
+VideoCaptureMF::VideoCaptureMF()
+    : reader_(nullptr)
+    , requested_capability_()
+    , output_capability_()
+    , ref_count_(1)
+    , manager_(nullptr) {
+  surface_handle_.reset(new owt::base::D3D11ImageHandle());
+}
+
+VideoCaptureMF::~VideoCaptureMF() {
+  capture_started_ = false;
+}
+
+bool VideoCaptureMF::Init(const char* device_unique_id_utf8, int32_t width,
+                          int32_t height, int32_t fps) {
+  // Max Count will be kVideoCaptureUniqueNameLength(Max UniqueName length)
+  const int32_t name_length = (int32_t)strnlen_s((char*)device_unique_id_utf8, kVideoCaptureDeviceNameLength);
+  if (name_length > kVideoCaptureUniqueNameLength)
+    return false;
+
+  // Store the device name
+  device_unique_id_.reset(new (std::nothrow) char[name_length + 1]);
+  if (!device_unique_id_) {
+    return false;
+  }
+  memcpy_s(device_unique_id_.get(), name_length + 1, device_unique_id_utf8,
+           name_length + 1);
+
+  if (info_.Init() != 0) {
+    return false;
+  }
+
+  // Get the Media Source from device info.
+  CComPtr<IMFMediaSource> source(info_.GetCaptureSource(device_unique_id_utf8));
+  if (!source) {
+    return false;
+  }
+
+  // Set the requested capabality
+  requested_capability_.width = width;
+  requested_capability_.height = height;
+  requested_capability_.maxFPS = fps;
+  requested_capability_.videoType = VideoType::kNV12;
+
+  // Get the best matching capability
+  VideoCaptureCapability capability;
+  int32_t capability_index;
+
+  // Store the new requested size
+  // Match the requested capability with the supported.
+  if ((capability_index = info_.GetBestMatchedCapability(
+           device_unique_id_.get(), requested_capability_, capability)) < 0) {
+    return false;
+  }
+
+  // Reduce the frame rate if possible.
+  if (capability.maxFPS > requested_capability_.maxFPS) {
+    capability.maxFPS = requested_capability_.maxFPS;
+  } else if (capability.maxFPS <= 0) {
+    capability.maxFPS = 30;
+  }
+
+  // Store the capability that is set to capture device
+  output_capability_ = capability;
+  RTC_LOG(LS_INFO) << "BestCapability Selected: width:"
+                   << capability.width << ", height:" << capability.height
+                   << ", FPS:" << capability.maxFPS
+                   << ", videoType:" << capability.videoType;
+
+  HRESULT hr = S_OK;
+
+  CComPtr<IMFMediaSourceEx> media_source_ex = nullptr;
+  if (output_capability_.videoType == webrtc::VideoType::kNV12) {
+    // Sharing the buffer is only when the camera output is NV12
+    manager_ = new rtc::RefCountedObject<owt::base::D3D11Manager>();
+    if (!manager_->Init()) {
+      RTC_LOG(LS_ERROR) << "Failed to initialize D3dD11 Manager.";
+      return false;
+    }
+    hr = source->QueryInterface(&media_source_ex);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "Failed to query IMFMediaSourceEx:"
+                        << std::system_category().message(hr);
+      manager_.release();
+      manager_ = nullptr;
+      // If IMFMediaSourceEx is not available, then we will directly use
+      // System memory to receive the frames.
+    }
+  }
+  if (media_source_ex && manager_ &&
+      FAILED(media_source_ex->SetD3DManager(manager_->GetManager()))) {
+    // If SetD3DManager fails means that media source does not support source-level attributes,
+    // trying to register for system memory buffers from MF.
+    RTC_LOG(LS_ERROR) << "SetD3DManager failed:"
+                      << std::system_category().message(hr);
+    manager_->Release();
+    manager_ = nullptr;
+    media_source_ex.Release();
+    media_source_ex = nullptr;
+  }
+
+  CComPtr<IMFAttributes> attributes = nullptr;
+  hr = MFCreateAttributes(&attributes, 1);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "MFCreateAttributes failed:"
+                      << std::system_category().message(hr);
+    return false;
+  }
+
+  // Set the Async Callback attribute on the store
+  hr = attributes->SetUnknown(MF_SOURCE_READER_ASYNC_CALLBACK, this);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR)
+        << "VideoCapturer: Setting Async Callback attribute failed:"
+        << std::system_category().message(hr);
+    return false;
+  }
+
+  hr = MFCreateSourceReaderFromMediaSource(source, attributes, &reader_);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "Creating IMFSourceReader failed:"
+                      << std::system_category().message(hr);
+    source->Shutdown();
+    return false;
+  }
+
+  // Set format to capture device
+  CComPtr<IMFMediaType> mediaType = nullptr;
+  hr = reader_->GetNativeMediaType(MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+                                   capability_index, &mediaType);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "GetNativeMediaType failed:"
+                      << std::system_category().message(hr);
+    return false;
+  }
+
+  hr = reader_->SetCurrentMediaType(MF_SOURCE_READER_FIRST_VIDEO_STREAM, nullptr, mediaType);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetCurrentMediaType failed:"
+                      << std::system_category().message(hr);
+    return false;
+  }
+
+  return true;
+}
+
+bool VideoCaptureMF::StartCapture(int32_t width, int32_t height, int32_t fps) {
+  if (capture_started_) {
+    return true;
+  }
+
+  if (!reader_) {
+    return false;
+  }
+
+  webrtc::MutexLock lock(&mutex_);
+  VideoCaptureCapability capability;
+  capability.width = width;
+  capability.height = height;
+  capability.maxFPS = fps;
+  capability.videoType = VideoType::kNV12;
+
+  if (FAILED(SetCameraOutput(capability))) {
+    return false;
+  }
+
+  // As Source Reader is running in async mode, need to request
+  // for first sample from the source.
+  HRESULT hr = reader_->ReadSample(MF_SOURCE_READER_FIRST_VIDEO_STREAM, 0,
+                                   nullptr, nullptr, nullptr, nullptr);
+  capture_started_ = SUCCEEDED(hr);
+
+  return SUCCEEDED(hr);
+}
+
+bool VideoCaptureMF::StopCapture() {
+  if (!capture_started_) {
+    return true;
+  }
+  webrtc::MutexLock lock(&mutex_);
+
+  if (reader_) {
+    HRESULT hr = reader_->Flush(MF_SOURCE_READER_ALL_STREAMS);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "SourceReader flush failed:"
+                        << std::system_category().message(hr);
+    }
+  }
+
+  capture_started_ = false;
+  return true;
+}
+
+// VideoSourceInterface Methods
+void VideoCaptureMF::AddOrUpdateSink(rtc::VideoSinkInterface<VideoFrame>* sink,
+    const rtc::VideoSinkWants& wants) {
+  webrtc::MutexLock lock(&mutex_);
+  broadcaster_.AddOrUpdateSink(sink, wants);
+}
+
+void VideoCaptureMF::RemoveSink(rtc::VideoSinkInterface<VideoFrame>* sink)
+{
+  webrtc::MutexLock lock(&mutex_);
+  broadcaster_.RemoveSink(sink);
+}
+
+// IMFSourceReaderCallback methods
+STDMETHODIMP VideoCaptureMF::OnReadSample(HRESULT hrStatus, DWORD dwStreamIndex,
+                                          DWORD dwStreamFlags, LONGLONG llTimestamp,
+                                          IMFSample* sample) {
+  if (!capture_started_)
+    return S_OK;
+
+  if (FAILED(hrStatus)) {
+    RTC_LOG(LS_ERROR) << "OnReadSample reports error:"
+                      << std::system_category().message(hrStatus);
+    // The source reader ignores the return value, so returning OK
+    return S_OK;
+  }
+
+  HRESULT hr = S_OK;
+  webrtc::MutexLock lock(&mutex_);
+
+  if (sample) {
+    IMFMediaBuffer* buffer;
+
+    if (manager_) {
+      hr = sample->GetBufferByIndex(0, &buffer);
+    } else {
+      hr = sample->ConvertToContiguousBuffer(&buffer);
+    }
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "Failed to retrieve buffer from IMFSample:"
+                        << std::system_category().message(hr);
+      // The source reader ignores the return value, so returning OK
+      return S_OK;
+    }
+    IncomingFrame(buffer, llTimestamp);
+  }
+
+  // Request for next frame
+  if (SUCCEEDED(hr)) {
+    hr = reader_->ReadSample((DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM, 0, nullptr, nullptr, nullptr, nullptr);
+  }
+
+  return S_OK;
+}
+
+void VideoCaptureMF::IncomingFrame(IMFMediaBuffer*& frame, int64_t capture_time) {
+  if (frame == nullptr) {
+    return;
+  }
+
+  DWORD frame_length = 0;
+
+  const int32_t width = output_capability_.width;
+  const int32_t height = output_capability_.height;
+
+  rtc::scoped_refptr<VideoFrameBuffer> buffer;
+
+  HRESULT hr = S_OK;
+  ID3D11Texture2D* texture = nullptr;
+  if (manager_) {
+    CComPtr<IMFDXGIBuffer> dxgi_buffer;
+    hr = frame->QueryInterface(&dxgi_buffer);
+    if (FAILED(hr)) {
+      RTC_LOG(LS_ERROR) << "Query DxgiBuffer failed:"
+                        << std::system_category().message(hr);
+      return;
+    }
+
+    // Retrieves the texture from dxgi buffer
+    if (FAILED(dxgi_buffer->GetResource(IID_PPV_ARGS(&texture)))) {
+      RTC_LOG(LS_ERROR) << "Retreiving the texture from dxgi buffer failed:"
+                        << std::system_category().message(hr);
+      return;
+    }
+    surface_handle_->d3d11_device = manager_->GetDevice();
+    surface_handle_->texture = std::move(texture);
+    surface_handle_->texture_array_index = 0;
+    rtc::scoped_refptr<owt::base::NativeHandleBuffer> buffer =
+        new rtc::RefCountedObject<owt::base::NativeHandleBuffer>(
+            (void*)surface_handle_.get(), width, height);
+    SAFE_RELEASE(frame);
+  } else {
+    if (FAILED(frame->GetCurrentLength(&frame_length))) {
+      return;
+    }
+
+    if (output_capability_.videoType != VideoType::kMJPEG &&
+        CalcBufferSize(output_capability_.videoType, width, abs(height)) != frame_length) {
+      RTC_LOG(LS_ERROR) << "Wrong Incoming frame length.";
+      return;
+    }
+    if (output_capability_.videoType == VideoType::kNV12) {
+      buffer = webrtc::NV12Buffer::Create(width, height);
+    } else {
+      int stride_y = width;
+      int stride_uv = (width + 1) / 2;
+      int target_width = width;
+      int target_height = abs(height);
+      BYTE* data = NULL;
+
+      if (FAILED(frame->Lock(&data, NULL, NULL))) {
+        SAFE_RELEASE(frame);
+        return;
+      }
+
+      // Setting absolute height (in case it was negative).
+      // In Windows, the image starts bottom left, instead of top left.
+      // Setting a negative source height, inverts the image (within LibYuv).
+      rtc::scoped_refptr<I420Buffer> i420_buffer = I420Buffer::Create(
+          target_width, target_height, stride_y, stride_uv, stride_uv);
+
+      int ret = libyuv::ConvertToI420(
+          data, frame_length, i420_buffer.get()->MutableDataY(),
+          i420_buffer.get()->StrideY(), i420_buffer.get()->MutableDataU(),
+          i420_buffer.get()->StrideU(), i420_buffer.get()->MutableDataV(),
+          i420_buffer.get()->StrideV(), 0, 0,  // No Cropping
+          width, height, target_width, target_height, libyuv::kRotate0,
+          ConvertVideoType(output_capability_.videoType));
+      if (ret < 0) {
+        RTC_LOG(LS_ERROR)
+            << "Failed to convert capture frame from type "
+            << static_cast<int>(output_capability_.videoType) << "to I420.";
+        i420_buffer.release();
+        SAFE_RELEASE(frame);
+        return;
+      }
+      buffer = std::move(i420_buffer);
+      if (FAILED(frame->Unlock())) {
+        buffer.release();
+        SAFE_RELEASE(frame);
+        return;
+      }
+      SAFE_RELEASE(frame);
+    }
+  }
+
+  VideoFrame captured_frame = VideoFrame::Builder()
+                                .set_video_frame_buffer(buffer)
+                                .set_timestamp_rtp(0)
+                                .set_timestamp_ms(rtc::TimeMillis())
+                                .set_rotation(kVideoRotation_0)
+                                .build();
+
+  // TODO(jianlin): The timestamp returned by callback is not the same clock source
+  // of webrtc. Should we set it?
+  //captured_frame.set_ntp_time_ms(capture_time);
+
+  broadcaster_.OnFrame(captured_frame);
+
+  return;
+}
+
+HRESULT VideoCaptureMF::SetCameraOutput(
+    const VideoCaptureCapability& requested_capability) {
+  if (requested_capability_ == requested_capability) {
+    return S_OK;
+  }
+
+  // Get the best matching capability
+  VideoCaptureCapability capability;
+  int32_t capabilityIndex;
+  std::string format;
+
+  // Store the new requested size
+  requested_capability_ = requested_capability;
+  // Match the requested capability with the supported.
+  if ((capabilityIndex = info_.GetBestMatchedCapability(
+           device_unique_id_.get(), requested_capability_, capability)) < 0) {
+    return S_FALSE;
+  }
+
+  // Reduce the frame rate if possible.
+  if (capability.maxFPS > requested_capability.maxFPS) {
+    capability.maxFPS = requested_capability.maxFPS;
+  } else if (capability.maxFPS <= 0) {
+    capability.maxFPS = 30;
+  }
+
+  // Set format to capture device
+  CComPtr<IMFMediaType> media_type = nullptr;
+  HRESULT hr = reader_->GetNativeMediaType(MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+      capabilityIndex, &media_type);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "GetNativeMediaType failed:"
+                      << std::system_category().message(hr);
+    return hr;
+  }
+
+  hr = reader_->SetCurrentMediaType(MF_SOURCE_READER_FIRST_VIDEO_STREAM, nullptr,
+                                    media_type);
+  if (FAILED(hr)) {
+    RTC_LOG(LS_ERROR) << "SetCurrentMediaType failed:"
+                      << std::system_category().message(hr);
+    return hr;
+  }
+
+  // Store the capability that is set to capture device
+  output_capability_ = capability;
+  RTC_LOG(LS_INFO) << "BestCapability Selected: width:"
+                   << capability.width << ", height:" << capability.height
+                   << ", FPS:" << capability.maxFPS
+                   << ", videoType:" << capability.videoType;
+
+  UINT32 width, height;
+  MFGetAttributeSize(media_type, MF_MT_FRAME_SIZE, &width, &height);
+  UINT32 numerator, denominator;
+  MFGetAttributeRatio(media_type, MF_MT_FRAME_RATE, &numerator, &denominator);
+  GUID subtype;
+  // Get the Video SubType for this media Type
+  media_type->GetGUID(MF_MT_SUBTYPE, &subtype);
+  if (subtype == MFVideoFormat_I420) {
+    format = "I420";
+  } else if (subtype == MFVideoFormat_IYUV) {
+    format = "IYUV";
+  } else if (subtype == MFVideoFormat_RGB24) {
+    format = "RGB24";
+  } else if (subtype == MFVideoFormat_YUY2) {
+    format = "YUY2";
+  } else if (subtype == MFVideoFormat_NV12) {
+    format = "NV12";
+  } else if (subtype == MFVideoFormat_RGB565) {
+    format = "RGB565";
+  } else if (subtype == MFVideoFormat_MJPG) {
+    format = "MJPG";
+  }
+  RTC_LOG(LS_INFO) << "VideoCapturer: Format set to camera, Width:" << width
+                   << ", height:" << height
+                   << ", FPS:" << numerator / denominator
+                   << ", subtype:" << format;
+  return hr;
+}
+} // namespace videocapturemodule
+} // namespace webrtc

--- a/talk/owt/sdk/base/win/video_capture_mf.cc
+++ b/talk/owt/sdk/base/win/video_capture_mf.cc
@@ -167,16 +167,17 @@ bool VideoCaptureMF::Init(const char* device_unique_id_utf8, int32_t width,
   }
 
   // Set format to capture device
-  CComPtr<IMFMediaType> mediaType = nullptr;
+  CComPtr<IMFMediaType> media_type = nullptr;
   hr = reader_->GetNativeMediaType(MF_SOURCE_READER_FIRST_VIDEO_STREAM,
-                                   capability_index, &mediaType);
+                                   capability_index, &media_type);
   if (FAILED(hr)) {
     RTC_LOG(LS_ERROR) << "GetNativeMediaType failed:"
                       << std::system_category().message(hr);
     return false;
   }
 
-  hr = reader_->SetCurrentMediaType(MF_SOURCE_READER_FIRST_VIDEO_STREAM, nullptr, mediaType);
+  hr = reader_->SetCurrentMediaType(MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+                                    nullptr, media_type);
   if (FAILED(hr)) {
     RTC_LOG(LS_ERROR) << "SetCurrentMediaType failed:"
                       << std::system_category().message(hr);
@@ -341,9 +342,9 @@ void VideoCaptureMF::IncomingFrame(IMFMediaBuffer*& frame, int64_t capture_time)
       int stride_uv = (width + 1) / 2;
       int target_width = width;
       int target_height = abs(height);
-      BYTE* data = NULL;
+      BYTE* data = nullptr;
 
-      if (FAILED(frame->Lock(&data, NULL, NULL))) {
+      if (FAILED(frame->Lock(&data, nullptr, nullptr))) {
         SAFE_RELEASE(frame);
         return;
       }
@@ -451,7 +452,7 @@ HRESULT VideoCaptureMF::SetCameraOutput(
   UINT32 numerator, denominator;
   MFGetAttributeRatio(media_type, MF_MT_FRAME_RATE, &numerator, &denominator);
   GUID subtype;
-  // Get the Video SubType for this media Type
+  // Get the video subType for this media type
   media_type->GetGUID(MF_MT_SUBTYPE, &subtype);
   if (subtype == MFVideoFormat_I420) {
     format = "I420";
@@ -467,6 +468,8 @@ HRESULT VideoCaptureMF::SetCameraOutput(
     format = "RGB565";
   } else if (subtype == MFVideoFormat_MJPG) {
     format = "MJPG";
+  } else {
+    format = "Others";
   }
   RTC_LOG(LS_INFO) << "VideoCapturer: Format set to camera, Width:" << width
                    << ", height:" << height

--- a/talk/owt/sdk/base/win/video_capture_mf.h
+++ b/talk/owt/sdk/base/win/video_capture_mf.h
@@ -1,0 +1,93 @@
+// Copyright (C) <2021> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OWT_BASE_WIN_VIDEO_CAPTURE_MF_H
+#define OWT_BASE_WIN_VIDEO_CAPTURE_MF_H
+
+#include <memory>
+#include <shlwapi.h>
+
+#include "webrtc/api/video/video_source_interface.h"
+#include "webrtc/media/base/video_broadcaster.h"
+#include "webrtc/rtc_base/synchronization/mutex.h"
+#include "talk/owt/sdk/base/win/d3d11_manager.h"
+#include "talk/owt/sdk/base/win/device_info_mf.h"
+#include "talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h"
+
+namespace webrtc {
+namespace videocapturemodule {
+
+class VideoCaptureMF
+    : public IMFSourceReaderCallback
+    , public rtc::VideoSourceInterface<VideoFrame> {
+protected:
+  VideoCaptureMF();
+
+public:
+  static std::unique_ptr<VideoCaptureMF> Create(const char* device_name, int32_t width,
+                                                int32_t height, int32_t fps);
+  virtual ~VideoCaptureMF();
+  bool Init(const char* device_unique_id_utf8, int32_t width,
+            int32_t height, int32_t fps);
+  bool StartCapture(int32_t width, int32_t height, int32_t fps);
+  bool StopCapture();
+
+  // IUnknown methods
+  STDMETHODIMP QueryInterface(REFIID iid, void** ppv) override {
+    static const QITAB qit[] = {
+        QITABENT(VideoCaptureMF, IMFSourceReaderCallback),
+        {0},
+    };
+    return QISearch(this, qit, iid, ppv);
+  }
+
+  STDMETHODIMP_(ULONG) AddRef() override {
+    return InterlockedIncrement(&ref_count_);
+  }
+
+  STDMETHODIMP_(ULONG) Release() override {
+    ULONG uCount = InterlockedDecrement(&ref_count_);
+    if (uCount == 0) {
+      delete this;
+    }
+    return uCount;
+  }
+
+private:
+  // IMFSourceReaderCallback methods
+  STDMETHODIMP OnReadSample(HRESULT hrStatus,
+                            DWORD dwStreamIndex,
+                            DWORD dwStreamFlags,
+                            LONGLONG llTimestamp,
+                            IMFSample* sample) override;
+
+  STDMETHODIMP OnEvent(DWORD, IMFMediaEvent*) override { return S_OK; }
+
+  STDMETHODIMP OnFlush(DWORD) override { return S_OK; }
+
+  // VideoSourceInterface Methods
+  void AddOrUpdateSink(rtc::VideoSinkInterface<VideoFrame>* sink,
+                               const rtc::VideoSinkWants& wants) override;
+  // RemoveSink must guarantee that at the time the method returns,
+  // there is no current and no future calls to VideoSinkInterface::OnFrame.
+  void RemoveSink(rtc::VideoSinkInterface<VideoFrame>* sink) override;
+
+  void IncomingFrame(IMFMediaBuffer*& frame, int64_t capture_time = 0);
+  HRESULT SetCameraOutput(const VideoCaptureCapability& requested_capability);
+
+  CComPtr<IMFSourceReader> reader_;
+  std::unique_ptr<char[]> device_unique_id_;  // Current Device Unique Name
+  DeviceInfoMF info_;
+  VideoCaptureCapability requested_capability_;
+  VideoCaptureCapability output_capability_;
+  rtc::VideoBroadcaster broadcaster_;
+  webrtc::Mutex mutex_;
+  long ref_count_;
+  bool capture_started_ = false;
+  rtc::scoped_refptr<owt::base::D3D11Manager> manager_;
+  std::unique_ptr<owt::base::D3D11ImageHandle> surface_handle_;
+};
+}
+}
+#endif //OWT_BASE_WIN_VIDEO_CAPTURE_MF_H


### PR DESCRIPTION
This pr implements media foundation based video capturerer as the preparing for zero-buffer copy between encoder and capturer on windows.

LocalStream creation with this new capturerer is not implemented, and will be enabled together with updated hardware encoder.

Media foundation based video capture require Win8 and Win10 to work.