### PR TITLE
Build script enable windows arm64 target

### DIFF
--- a/scripts/build-win.py
+++ b/scripts/build-win.py
@@ -24,7 +24,6 @@ PARALLEL_TEST_TARGET_LIST = ['rtc_unittests', 'video_engine_tests']
 NONPARALLEL_TEST_TARGET_LIST = ['webrtc_nonparallel_tests']
 
 GN_ARGS = [
-    'is_clang=false',
     'rtc_use_h264=true',
     'ffmpeg_branding="Chrome"',
     'rtc_use_h265=true',
@@ -39,6 +38,8 @@ GN_ARGS = [
 def gngen(arch, ssl_root, msdk_root, quic_root, scheme, tests):
     gn_args = list(GN_ARGS)
     gn_args.append('target_cpu="%s"' % arch)
+    if arch != 'arm64':
+        gn_args.append('is_clang=false')
     if scheme == 'release':
         gn_args.append('is_debug=false')
     else:
@@ -170,8 +171,8 @@ def pack_sdk(scheme, output_path):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--arch', default='x86', dest='arch', choices=('x86', 'x64'),
-                        help='Target architecture. Supported value: x86, x64')
+    parser.add_argument('--arch', default='x86', dest='arch', choices=('x86', 'x64', 'arm64'),
+                        help='Target architecture. Supported value: x86, x64, arm64')
     parser.add_argument('--ssl_root', help='Path for OpenSSL.')
     parser.add_argument('--msdk_root', help='Path for MSDK.')
     parser.add_argument('--quic_root', help='Path to QUIC library')

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -16,8 +16,6 @@ if (is_win) {
  } else if (current_cpu == "arm") {
    if (arm_use_neon) {
      cpu_arch_full = "arm-neon"
-   } else if (is_android) {
-     cpu_arch_full = "arm-neon-cpu-detect"
    } else {
      cpu_arch_full = "arm"
    }
@@ -254,6 +252,7 @@ static_library("owt_sdk_base") {
   }
   if (is_linux) {
     if (owt_msdk_header_root != "") {
+      include_dirs += [ owt_msdk_header_root ]
       sources += [
         "sdk/base/linux/displayutils.cc",
         "sdk/base/linux/displayutils.h",

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -7,23 +7,22 @@ import("//testing/test.gni")
 
 # Introduced for using libvpx config files. We only enable libvpx rate
 # controller for VP9 on Windows.
-#if (is_win) {
-#  os_category = current_os
-#
-#  if (current_cpu == "x86") {
-#    cpu_arch_full = "ia32"
-#  } else if (current_cpu == "x64") {
-#    cpu_arch_full = "x64"
-#  } else if (current_cpu == "arm") {
-#    if (arm_use_neon) {
-#      cpu_arch_full = "arm-neon"
-#    } else if (is_android) {
-#      cpu_arch_full = "arm-neon-cpu-detect"
-#    } else {
-#      cpu_arch_full = "arm"
-#    }
-#  }
-#}
+if (is_win) {
+ 
+ if (current_cpu == "x86") {
+   cpu_arch_full = "ia32"
+ } else if (current_cpu == "x64") {
+   cpu_arch_full = "x64"
+ } else if (current_cpu == "arm") {
+   if (arm_use_neon) {
+     cpu_arch_full = "arm-neon"
+   } else if (is_android) {
+     cpu_arch_full = "arm-neon-cpu-detect"
+   } else {
+     cpu_arch_full = "arm"
+   }
+ }
+}
 
 if (is_android) {
   import("//build/config/android/config.gni")
@@ -209,7 +208,7 @@ static_library("owt_sdk_base") {
     public_deps += [ "//third_party/libvpx" ]
     include_dirs += [
       "//third_party/libvpx/source/config",
-      "//third_party/libvpx/source/config/$os_category/$cpu_arch_full",
+      "//third_party/libvpx/source/config/$current_os/$cpu_arch_full",
       "//third_party/libvpx/source/libvpx",
     ]
   }
@@ -255,8 +254,6 @@ static_library("owt_sdk_base") {
   }
   if (is_linux) {
     if (owt_msdk_header_root != "") {
-      include_dirs += [ owt_msdk_header_root ]
-      defines += [ "OWT_USE_MSDK" ]
       sources += [
         "sdk/base/linux/displayutils.cc",
         "sdk/base/linux/displayutils.h",

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -258,6 +258,7 @@ static_library("owt_sdk_base") {
   if (is_linux) {
     if (owt_msdk_header_root != "") {
       include_dirs += [ owt_msdk_header_root ]
+      defines += [ "OWT_USE_MSDK" ]
       sources += [
         "sdk/base/linux/displayutils.cc",
         "sdk/base/linux/displayutils.h",

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -7,23 +7,23 @@ import("//testing/test.gni")
 
 # Introduced for using libvpx config files. We only enable libvpx rate
 # controller for VP9 on Windows.
-if (is_win) {
-  os_category = current_os
-
-  if (current_cpu == "x86") {
-    cpu_arch_full = "ia32"
-  } else if (current_cpu == "x64") {
-    cpu_arch_full = "x64"
-  } else if (current_cpu == "arm") {
-    if (arm_use_neon) {
-      cpu_arch_full = "arm-neon"
-    } else if (is_android) {
-      cpu_arch_full = "arm-neon-cpu-detect"
-    } else {
-      cpu_arch_full = "arm"
-    }
-  }
-}
+#if (is_win) {
+#  os_category = current_os
+#
+#  if (current_cpu == "x86") {
+#    cpu_arch_full = "ia32"
+#  } else if (current_cpu == "x64") {
+#    cpu_arch_full = "x64"
+#  } else if (current_cpu == "arm") {
+#    if (arm_use_neon) {
+#      cpu_arch_full = "arm-neon"
+#    } else if (is_android) {
+#      cpu_arch_full = "arm-neon-cpu-detect"
+#    } else {
+#      cpu_arch_full = "arm"
+#    }
+#  }
+#}
 
 if (is_android) {
   import("//build/config/android/config.gni")
@@ -203,6 +203,14 @@ static_library("owt_sdk_base") {
       "sdk/base/win/sysmem_allocator.cc",
       "sdk/base/win/sysmem_allocator.h",
       "sdk/base/win/vpedefs.h",
+      "sdk/base/win/vp9ratecontrol.cc",
+      "sdk/base/win/vp9ratecontrol.h",
+    ]
+    public_deps += [ "//third_party/libvpx" ]
+    include_dirs += [
+      "//third_party/libvpx/source/config",
+      "//third_party/libvpx/source/config/$os_category/$cpu_arch_full",
+      "//third_party/libvpx/source/libvpx",
     ]
   }
 
@@ -240,17 +248,10 @@ static_library("owt_sdk_base") {
       "sdk/base/win/videorendererwin.h",
       "sdk/base/win/videorendererd3d11.cc",
       "sdk/base/win/videorendererd3d11.h",
-      "sdk/base/win/vp9ratecontrol.cc",
-      "sdk/base/win/vp9ratecontrol.h",
       "sdk/base/windowcapturer.cc",
     ]
     public_deps += [ "//third_party/webrtc/modules/audio_device:audio_device_module_from_input_and_output" ]
-    public_deps += [ "//third_party/libvpx" ]
-    include_dirs += [
-      "//third_party/libvpx/source/config",
-      "//third_party/libvpx/source/config/$os_category/$cpu_arch_full",
-      "//third_party/libvpx/source/libvpx",
-    ]
+    
   }
   if (is_linux) {
     if (owt_msdk_header_root != "") {


### PR DESCRIPTION
Enable Windows on arm64 compile target support using the VC cross compile toolchain, some modifications to build_win.py and owt\talk\BUILD.gn to support compilation