### PR TITLE
Switch from QuicTransport to WebTransport for conference SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ The following dependencies are for Windows only:
 - Create a file named .gclient in the directory above the `src` dir, with these contents:
 
 ```
-solutions = [ 
-  {  
-     "managed": False,  
-     "name": "src",  
-     "url": "https://github.com/open-webrtc-toolkit/owt-client-native.git",  
-     "custom_deps": {},  
-     "deps_file": "DEPS",  
-     "safesync_url": "",  
-  },  
-]  
-target_os = []  
+solutions = [
+  {
+     "managed": False,
+     "name": "src",
+     "url": "https://github.com/open-webrtc-toolkit/owt-client-native.git",
+     "custom_deps": {},
+     "deps_file": "DEPS",
+     "safesync_url": "",
+  },
+]
+target_os = []
 ```
 
 ### Build
@@ -67,7 +67,8 @@ Common build options shared by Windows and Linux:
   - The built binary will be under path specified by `--output_path`. If `--output_path` is not set, the built binary will be under `src/out` directory.
   - The optional `--ssl_root` should be set to the root directory of lastest OpenSSL 1.1.1 binary. If specified, SDK will link to external openssl library instead of boringssl.
   - Use `--gn_gen` to generate args.gn during the first build or when you change either `ssl_root`/`msdk_root`/`quic_root` options.
-  - The optional `--quic_root` should point to the directory containing QUIC library pre-built from owt-sdk-quic repo. This will build the SDK with QUIC enabled for conference mode.
+  - The optional `--quic_root` should point to the directory containing WebTransport library pre-built from owt-sdk-quic repo. This will build the SDK with WebTransport enabled for 
+  conference mode. Refer to [README.webtransport](https://github.com/open-webrtc-toolkit/owt-client-native/blob/main/README.webtransport) for the version of webtransport library to be used.
   - The optional `--tests` will trigger unit tests after build.
 
 #### iOS

--- a/README.webtransport
+++ b/README.webtransport
@@ -1,0 +1,4 @@
+WebTransport SDK version:
+===================================
+Repo URL: https://github.com/open-webrtc-toolkit/owt-sdk-quic
+Revision: c53899b14b5b24e796ad51bd36c8d02ddb8cde48

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -5,9 +5,15 @@
 import("//build_overrides/webrtc.gni")
 import("//testing/test.gni")
 
+declare_args() {
+  include_internal_audio_device = true
+  owt_msdk_lib_root = ""
+  owt_msdk_header_root = ""
+}
+
 # Introduced for using libvpx config files. We only enable libvpx rate
 # controller for VP9 on Windows.
-if (is_win) {
+if (is_win && owt_msdk_header_root != "") {
  
  if (current_cpu == "x86") {
    cpu_arch_full = "ia32"
@@ -26,19 +32,17 @@ if (is_android) {
   import("//build/config/android/config.gni")
   import("//build/config/android/rules.gni")
 }
+
 if (is_ios) {
   import("//build/config/ios/rules.gni")
 }
-declare_args() {
-  include_internal_audio_device = true
-  owt_msdk_lib_root = ""
-  owt_msdk_header_root = ""
-}
+
 if (is_ios || is_mac) {
   config("owt_sdk_objc_warnings_config") {
     cflags_objc = [ "-Wstrict-prototypes" ]
   }
 }
+
 if (is_android) {
   config("libjingle_peerconnection_jni_warnings_config") {
     # The warnings below are enabled by default. Since GN orders compiler flags
@@ -52,6 +56,7 @@ if (is_android) {
     }
   }
 }
+
 static_library("owt_deps") {
   deps = [
     "//third_party/webrtc/api:create_peerconnection_factory",
@@ -66,6 +71,7 @@ static_library("owt_deps") {
   }
   complete_static_lib = true
 }
+
 if (!is_ios) {
   static_library("owt") {
     deps = [

--- a/talk/owt/docs/cpp/cpp.md
+++ b/talk/owt/docs/cpp/cpp.md
@@ -7,14 +7,14 @@ This SDK is interoperable with Open WebRTC Toolkit Client SDK for JavaScript\*, 
 Refer to the Release Notes for the latest information in the SDK release package, including features,
 bug fixes and known issues.
 # 2 Supported platforms {#section2}
-Open WebRTC Toolkit Client SDK for Windows supports Windows 7 and later versions.
+Open WebRTC Toolkit Client SDK for Windows supports Windows 8 and later versions.
 # 3 Getting started {#section3}
 Application on Open WebRTC Toolkit Client SDK for Windows should be built with Microsoft Visual Studio\* 2017 or 2019. Running time library for linking should be `Multi-threaded Debug (/MTd)` for debug version or `Multi-threaded (/MT)` for release version. Supported platform is x64.
 The release package includes one sample application to get you started quickly with the SDK. The following two static libraries are provided in the SDK for only x64, along with their headers:
 - owt-debug.lib - this library includes all the WebRTC features for debug usages.
 - owt-release.lib - this library includes all the WebRTC features for release usages.
 owt-debug.lib|owt-release references libraries in Windows SDK for DXVA support. Your application must statically link
-mfuuid.lib, mf.lib, mfplat.lib, d3d9.lib, dxgi.lib, d3d11.lib and dxva2.lib to build. Depending on your signaling
+mfuuid.lib, mf.lib, mfplat.lib, d3d9.lib, dxgi.lib, d3d11.lib, dcomp.lib and dxva2.lib to build. Depending on your signaling
 channel implementation, you can optionally link sioclient.lib or sioclient_tls.lib if neccessary.
 # 4 Socket.IO {#section4}
 Socket.IO cpp client is an open source project hosted on [Github](https://github.com/socketio/socket.io-client-cpp). Please follow official guide on GitHub to build and link it. The version works with OWT is b1216ee428dd7d1e72368da9b12aa43bfc487c93.
@@ -29,8 +29,8 @@ for P2P sessions can be customized by implementing `P2PSignalingChannelInterface
 can invoke its methods to notify `PeerClient` during your customized signaling channel implementation when a new
 message is coming or connection is lost.
 # 7 Video codecs {#section7}
-For the decoder, if hardware acceleration is not enabled, only VP8/VP9 is supported. If hardware acceleration is enabled, VP8,
-VP9, H.264 and HEVC are supported, but it will fallback to VP8 software decoder if GPU does not supports VP8 hardware decoding.
+For the decoder, if hardware acceleration is not enabled, only VP8/VP9/AV1 is supported. If hardware acceleration is enabled, VP8,
+VP9, H.264, HEVC and AV1 are supported, but it will fallback to VP8 software decoder if GPU does not supports VP8 hardware decoding.
 Most of the 5th-11th Generation Intel<sup>®</sup> Core(TM) Processor platforms support VP8 hardware decoding, refer to their specific documentation for details.
 Starting from 6th Generation Intel<sup>®</sup> Core(TM) Processor platforms, hardware encoding and decoding of HEVC is supported.
 You can turn off video encoding/decoding hardware acceleration via {@link owt.base.GlobalConfiguration GlobalConfiguration} API,

--- a/talk/owt/sdk/base/stream.cc
+++ b/talk/owt/sdk/base/stream.cc
@@ -720,17 +720,13 @@ MediaStreamInterface* RemoteStream::MediaStream() {
 }
 
 #ifdef OWT_ENABLE_QUIC
-QuicStream::QuicStream(owt::quic::QuicTransportStreamInterface* quic_stream,
+QuicStream::QuicStream(owt::quic::WebTransportStreamInterface* quic_stream,
            const std::string& session_id)
     : quic_stream_(quic_stream), session_id_(session_id), can_read_(true),
       can_write_(true), fin_read_(false) {
 }
 
 QuicStream::~QuicStream() {
-  if (quic_stream_) {
-    delete quic_stream_;
-    quic_stream_ = nullptr;
-  }
 }
 
 size_t QuicStream::Write(uint8_t* data, size_t length) {

--- a/talk/owt/sdk/conference/conferenceclient.cc
+++ b/talk/owt/sdk/conference/conferenceclient.cc
@@ -255,7 +255,7 @@ void ConferenceClient::OnConnectionFailed() {
 }
 
 void ConferenceClient::OnIncomingStream(const std::string& session_id,
-  owt::quic::QuicTransportStreamInterface* stream) {
+  owt::quic::WebTransportStreamInterface* stream) {
   RTC_LOG(LS_INFO) << "Quic client received a stream on session:" << session_id;
   // Check if the subscription exists for this stream. Trigger immediately
   // if exists. Otherwise push to pending list.
@@ -1046,11 +1046,11 @@ void ConferenceClient::Leave(
   }
 #ifdef OWT_ENABLE_QUIC
   {
-    std::lock_guard<std::mutex> lock(quic_publications_mutex_);
+    // Do not hold the lock of quic_publications_ as only Stop
+    // will remove the publications from list.
     for (auto& publication : quic_publications_) {
       publication.second->Stop();
     }
-    quic_publications_.clear();
   }
   {
     std::lock_guard<std::mutex> lock(quic_subscriptions_mutex_);
@@ -1725,7 +1725,7 @@ void ConferenceClient::TriggerOnUserLeft(sio::message::ptr user_info) {
 #ifdef OWT_ENABLE_QUIC
 void ConferenceClient::TriggerOnIncomingStream(
     const std::string& session_id,
-                             owt::quic::QuicTransportStreamInterface* stream) {
+                             owt::quic::WebTransportStreamInterface* stream) {
   const std::lock_guard<std::mutex> lock(stream_update_observer_mutex_);
   for (auto its = stream_update_observers_.begin();
        its != stream_update_observers_.end(); ++its) {

--- a/talk/owt/sdk/conference/conferencesubscription.cc
+++ b/talk/owt/sdk/conference/conferencesubscription.cc
@@ -211,7 +211,7 @@ void ConferenceSubscription::OnStreamError(const std::string& error_msg) {
 
 #ifdef OWT_ENABLE_QUIC
 void ConferenceSubscription::OnIncomingStream(const std::string& session_id,
-    owt::quic::QuicTransportStreamInterface* stream) {
+    owt::quic::WebTransportStreamInterface* stream) {
   if (ended_ || stream_id_ != session_id)
     return;
   quic_stream_ = std::make_shared<owt::base::QuicStream>(stream, session_id);

--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -17,7 +17,7 @@
 #include "owt/base/videorendererinterface.h"
 #include "owt/base/audioplayerinterface.h"
 #ifdef OWT_ENABLE_QUIC
-#include "owt/quic/quic_transport_stream_interface.h"
+#include "owt/quic/web_transport_stream_interface.h"
 #endif
 
 namespace webrtc {
@@ -178,9 +178,9 @@ class Stream {
 /// A QuicStream can be fetched from a published LocalStream for data,
 /// on which you can write to server;
 /// Or from a subscription from server for data, on which you can read.
-class QuicStream : public owt::quic::QuicTransportStreamInterface::Visitor {
+class QuicStream : public owt::quic::WebTransportStreamInterface::Visitor {
  public:
-  QuicStream(owt::quic::QuicTransportStreamInterface* quic_stream,
+  QuicStream(owt::quic::WebTransportStreamInterface* quic_stream,
              const std::string& session_id);
   ~QuicStream();
 
@@ -207,7 +207,7 @@ class QuicStream : public owt::quic::QuicTransportStreamInterface::Visitor {
    @return Bytes of data available on the stream.
   */
   size_t ReadableBytes() const;
-  void SetVisitor(owt::quic::QuicTransportStreamInterface::Visitor* visitor) {
+  void SetVisitor(owt::quic::WebTransportStreamInterface::Visitor* visitor) {
     if (quic_stream_ && visitor) {
       quic_stream_->SetVisitor(visitor);
     }
@@ -228,7 +228,8 @@ class QuicStream : public owt::quic::QuicTransportStreamInterface::Visitor {
   }
   /** @endcond */
  private:
-  owt::quic::QuicTransportStreamInterface* quic_stream_;
+  // Owned by WebTransportClientImpl.
+  owt::quic::WebTransportStreamInterface* quic_stream_;
   std::string session_id_;
   std::atomic<bool> can_read_;
   std::atomic<bool> can_write_;

--- a/talk/owt/sdk/include/cpp/owt/base/subscription.h
+++ b/talk/owt/sdk/include/cpp/owt/base/subscription.h
@@ -6,7 +6,7 @@
 #include "owt/base/commontypes.h"
 #include "owt/base/mediaconstraints.h"
 #ifdef OWT_ENABLE_QUIC
-#include "owt/quic/quic_transport_stream_interface.h"
+#include "owt/quic/web_transport_stream_interface.h"
 #endif
 namespace owt {
 namespace base {

--- a/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
@@ -22,7 +22,7 @@
 #include "owt/conference/streamupdateobserver.h"
 #include "owt/conference/subscribeoptions.h"
 #ifdef OWT_ENABLE_QUIC
-#include "owt/quic/quic_transport_stream_interface.h"
+#include "owt/quic/web_transport_stream_interface.h"
 #endif
 namespace sio{
   class message;
@@ -209,7 +209,7 @@ class ConferenceWebTransportChannelObserver {
   // Called when an incoming stream is received by QUIC channel
   virtual void OnIncomingStream(
       const std::string& session_id,
-      owt::quic::QuicTransportStreamInterface* stream) = 0;
+      owt::quic::WebTransportStreamInterface* stream) = 0;
 };
 #endif
 /** @endcond */
@@ -445,7 +445,7 @@ class ConferenceClient final
   void OnConnected();
   void OnConnectionFailed();
   void OnIncomingStream(const std::string& session_id,
-                        owt::quic::QuicTransportStreamInterface* stream);
+                        owt::quic::WebTransportStreamInterface* stream);
 #endif
 
   /// Return true if |pointer| is not a null pointer, else return false and
@@ -476,7 +476,7 @@ class ConferenceClient final
                             std::shared_ptr<const Exception> exception);
 #ifdef OWT_ENABLE_QUIC
   void TriggerOnIncomingStream(const std::string& session_id,
-                               owt::quic::QuicTransportStreamInterface* stream);
+                               owt::quic::WebTransportStreamInterface* stream);
 #endif
   // Return true if |user_info| is correct, and |*participant| points to the participant
   // object
@@ -529,17 +529,19 @@ class ConferenceClient final
   mutable std::mutex stream_update_observer_mutex_;
   std::vector <std::reference_wrapper<ConferenceStreamUpdateObserver>> stream_update_observers_;
 #ifdef OWT_ENABLE_QUIC
-  // Each conference client will be associated with one quic_transport_channel_ instance.
+  // Each conference client will be associated with only one quic_transport_channel_ instance.
   std::shared_ptr<ConferenceWebTransportChannel> web_transport_channel_;
   std::atomic<bool> web_transport_channel_connected_;
   std::string webtransport_id_;  // transportId used for publish/subscribe.
-  std::string webtransport_token_; // base64 encoded webTransportToken recevied after joining. key is session_id(publication_id)
+  // base64 encoded webTransportToken recevied after joining. key is
+  // session_id(publication_id)
+  std::string webtransport_token_;
   std::map<std::string, std::shared_ptr<ConferencePublication>> quic_publications_;
   mutable std::mutex quic_publications_mutex_;
   // key is session_id(subscription_id)
   std::map<std::string, std::shared_ptr<ConferenceSubscription>> quic_subscriptions_;
   mutable std::mutex quic_subscriptions_mutex_;
-  std::unordered_map<std::string, QuicTransportStreamInterface*>
+  std::unordered_map<std::string, WebTransportStreamInterface*>
       pending_incoming_streams_;
   mutable std::mutex pending_quic_streams_mutex_;
 #endif

--- a/talk/owt/sdk/include/cpp/owt/conference/conferencesubscription.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferencesubscription.h
@@ -78,7 +78,7 @@ class ConferenceSubscription : public ConferenceStreamUpdateObserver,
     void OnStreamRemoved(const std::string& stream_id);
     void OnStreamError(const std::string& error_msg);
 #ifdef OWT_ENABLE_QUIC
-    void OnIncomingStream(const std::string& session_id, owt::quic::QuicTransportStreamInterface* stream);
+    void OnIncomingStream(const std::string& session_id, owt::quic::WebTransportStreamInterface* stream);
 #endif
     std::string id_;
     std::string stream_id_;

--- a/talk/owt/sdk/include/cpp/owt/conference/streamupdateobserver.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/streamupdateobserver.h
@@ -5,7 +5,7 @@
 #define OWT_CONFERENCE_STREAMUPDATEOBSERVER_H
 #include "owt/base/commontypes.h"
 #ifdef OWT_ENABLE_QUIC
-#include "owt/quic/quic_transport_stream_interface.h"
+#include "owt/quic/web_transport_stream_interface.h"
 #endif
 namespace owt {
 namespace conference {
@@ -22,7 +22,7 @@ public:
   virtual void OnStreamError(const std::string& error_msg){}
 #ifdef OWT_ENABLE_QUIC
   virtual void OnIncomingStream(
-      const std::string& session_id, owt::quic::QuicTransportStreamInterface* stream) {}
+      const std::string& session_id, owt::quic::WebTransportStreamInterface* stream) {}
 #endif
 };
 /** @endcond */


### PR DESCRIPTION
Switch from quictransport to webtransport to accommodate to server's switch. 