### PR TITLE
Ensure llvm builds don't use libc++

### DIFF
--- a/scripts/build-win.py
+++ b/scripts/build-win.py
@@ -38,6 +38,7 @@ GN_ARGS = [
 def gngen(arch, ssl_root, msdk_root, quic_root, scheme, tests):
     gn_args = list(GN_ARGS)
     gn_args.append('target_cpu="%s"' % arch)
+    using_llvm = False
     if arch == 'arm64':
         using_llvm = True
     if  not using_llvm:

--- a/scripts/build-win.py
+++ b/scripts/build-win.py
@@ -38,7 +38,9 @@ GN_ARGS = [
 def gngen(arch, ssl_root, msdk_root, quic_root, scheme, tests):
     gn_args = list(GN_ARGS)
     gn_args.append('target_cpu="%s"' % arch)
-    if arch != 'arm64':
+    if arch == 'arm64':
+        using_llvm = True
+    if  not using_llvm:
         gn_args.append('is_clang=false')
     else:
         gn_args.append('libcxx_abi_unstable=false')

--- a/scripts/build-win.py
+++ b/scripts/build-win.py
@@ -32,7 +32,7 @@ GN_ARGS = [
     'enable_libaom=true',
     'rtc_build_examples=false',
     'treat_warnings_as_errors=false',
-]
+    ]
 
 
 def gngen(arch, ssl_root, msdk_root, quic_root, scheme, tests):
@@ -40,6 +40,10 @@ def gngen(arch, ssl_root, msdk_root, quic_root, scheme, tests):
     gn_args.append('target_cpu="%s"' % arch)
     if arch != 'arm64':
         gn_args.append('is_clang=false')
+    else:
+        gn_args.append('libcxx_abi_unstable=false')
+        gn_args.append('use_custom_libcxx_for_host=false')
+        gn_args.append('use_custom_libcxx=false')
     if scheme == 'release':
         gn_args.append('is_debug=false')
     else:


### PR DESCRIPTION
Cross compiling support in webrtc is only supported using llvm/clang, and by default uses a version of clang that is prebuilt by google. This version also enables libc++ (clang) experimental features (from c++11) in nested namespaces, which can conflict with other binaries built with the system clang tool/toolchain using msvc++ libraries. Disabling the experimental features, and disabling using the custom llvm/clang allows client libraries compiled on the same win system using the msvcpp toolchain