### PR TITLE
Add HEVC support.

### DIFF
--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -222,10 +222,8 @@ static_library("owt_sdk_base") {
     defines += [ "WEBRTC_USE_X11" ]
   }
 
-  if (!rtc_use_h265) {
-    defines += [ "DISABLE_H265" ]
-  } else {
-    defines += [ "OWT_USE_H265" ]
+  if (rtc_use_h265) {
+    defines += [ "WEBRTC_USE_H265" ]
   }
 
   if (owt_use_quic) {

--- a/talk/owt/sdk/base/codecutils.cc
+++ b/talk/owt/sdk/base/codecutils.cc
@@ -36,7 +36,7 @@ std::vector<webrtc::SdpVideoFormat> CodecUtils::SupportedH264Codecs() {
                            webrtc::H264Level::kLevel3_1, "0")};
 }
 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 std::vector<webrtc::SdpVideoFormat> CodecUtils::GetSupportedH265Codecs() {
   return {webrtc::SdpVideoFormat(cricket::kH265CodecName,
                                  {{cricket::kH265FmtpProfileSpace, "0"},
@@ -58,7 +58,7 @@ webrtc::VideoCodecType CodecUtils::ConvertSdpFormatToCodecType(
     return webrtc::kVideoCodecVP9;
   } else if (absl::EqualsIgnoreCase(format.name, cricket::kH264CodecName)) {
     return webrtc::kVideoCodecH264;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   } else if (absl::EqualsIgnoreCase(format.name, cricket::kH265CodecName)) {
     return webrtc::kVideoCodecH265;
 #endif

--- a/talk/owt/sdk/base/codecutils.h
+++ b/talk/owt/sdk/base/codecutils.h
@@ -14,7 +14,7 @@ namespace base {
 class CodecUtils {
  public:
   static std::vector<webrtc::SdpVideoFormat> SupportedH264Codecs();
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   static std::vector<webrtc::SdpVideoFormat> GetSupportedH265Codecs();
 #endif
   static webrtc::VideoCodecType ConvertSdpFormatToCodecType(webrtc::SdpVideoFormat format);

--- a/talk/owt/sdk/base/customizedvideodecoderfactory.cc
+++ b/talk/owt/sdk/base/customizedvideodecoderfactory.cc
@@ -38,7 +38,7 @@ CustomizedVideoDecoderFactory::CreateVideoDecoder(
     supported_codecs.push_back(format);
   for (const webrtc::SdpVideoFormat& format : owt::base::CodecUtils::SupportedH264Codecs())
     supported_codecs.push_back(format);
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   for (const webrtc::SdpVideoFormat& format : CodecUtils::GetSupportedH265Codecs()) {
     supported_codecs.push_back(format);
   }

--- a/talk/owt/sdk/base/customizedvideoencoderproxy.cc
+++ b/talk/owt/sdk/base/customizedvideoencoderproxy.cc
@@ -78,7 +78,7 @@ int32_t CustomizedVideoEncoderProxy::Encode(
       media_codec = VideoCodec::kH264;
     else if (codec_type_ == webrtc::kVideoCodecVP8)
       media_codec = VideoCodec::kVp8;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     else if (codec_type_ == webrtc::kVideoCodecH265)
       media_codec = VideoCodec::kH265;
 #endif
@@ -102,7 +102,7 @@ int32_t CustomizedVideoEncoderProxy::Encode(
     RTC_LOG(LS_ERROR) << "Invalid native handle passed.";
     return WEBRTC_VIDEO_CODEC_ERROR;
   } else {  // normal case.
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     if (codec_type_ != webrtc::kVideoCodecH264 &&
         codec_type_ != webrtc::kVideoCodecVP8 &&
         codec_type_ != webrtc::kVideoCodecVP9 &&

--- a/talk/owt/sdk/base/encodedvideoencoderfactory.cc
+++ b/talk/owt/sdk/base/encodedvideoencoderfactory.cc
@@ -23,7 +23,7 @@ EncodedVideoEncoderFactory::CreateVideoEncoder(
   if (absl::EqualsIgnoreCase(format.name, cricket::kVp8CodecName) ||
       absl::EqualsIgnoreCase(format.name, cricket::kVp9CodecName) ||
       absl::EqualsIgnoreCase(format.name, cricket::kH264CodecName)
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
       || absl::EqualsIgnoreCase(format.name, cricket::kH265CodecName)
 #endif
   ) {
@@ -42,7 +42,7 @@ EncodedVideoEncoderFactory::GetSupportedFormats() const {
   // supports with those provided by built-in H.264 encoder
   for (const webrtc::SdpVideoFormat& format : owt::base::CodecUtils::SupportedH264Codecs())
     supported_codecs.push_back(format);
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   for (const webrtc::SdpVideoFormat& format : CodecUtils::GetSupportedH265Codecs()) {
     supported_codecs.push_back(format);
   }

--- a/talk/owt/sdk/base/linux/msdkvideodecoderfactory.cc
+++ b/talk/owt/sdk/base/linux/msdkvideodecoderfactory.cc
@@ -34,7 +34,7 @@ std::unique_ptr<webrtc::VideoDecoder> MSDKVideoDecoderFactory::CreateVideoDecode
       return (std::unique_ptr<webrtc::VideoDecoder>)new MsdkVideoDecoder();
   } else if (absl::EqualsIgnoreCase(format.name, cricket::kVp9CodecName)) {
     return webrtc::VP9Decoder::Create();
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   } else if (absl::EqualsIgnoreCase(format.name, cricket::kH265CodecName)) {
     //return MSDKVideoDecoder::Create(cricket::VideoCodec(format));
 #endif
@@ -51,7 +51,7 @@ std::vector<webrtc::SdpVideoFormat> MSDKVideoDecoderFactory::GetSupportedFormats
     supported_codecs.push_back(format);
   for (const webrtc::SdpVideoFormat& format : owt::base::CodecUtils::SupportedH264Codecs())
     supported_codecs.push_back(format);
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   for (const webrtc::SdpVideoFormat& format : CodecUtils::GetSupportedH265Codecs()) {
     supported_codecs.push_back(format);
   }

--- a/talk/owt/sdk/base/mediautils.h
+++ b/talk/owt/sdk/base/mediautils.h
@@ -152,7 +152,7 @@ struct H265CodecCapability {
 
 union CodecSpecificInfoUnion {
   VP9CodecCapability VP9;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   H265CodecCapability H265;
 #endif
   H264CodecCapability H264;

--- a/talk/owt/sdk/base/objc/OWTDefaultVideoDecoderFactory.m
+++ b/talk/owt/sdk/base/objc/OWTDefaultVideoDecoderFactory.m
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #import "RTCEncodedImage.h"
-#if defined(OWT_USE_H265)
+#if defined(WEBRTC_USE_H265)
 #import "RTCVideoCodecH265.h"
 #endif
 #import "talk/owt/sdk/base/objc/OWTDefaultVideoDecoderFactory.h"
 @implementation OWTDefaultVideoDecoderFactory
 - (id<RTCVideoDecoder>)createDecoder:(RTCVideoCodecInfo*)info {
-#if defined(OWT_USE_H265)
+#if defined(WEBRTC_USE_H265)
   if (@available(iOS 11.0, *)) {
     if ([info.name isEqualToString:kRTCVideoCodecH265Name]) {
       return [[RTCVideoDecoderH265 alloc] init];
@@ -21,7 +21,7 @@
 - (NSArray<RTCVideoCodecInfo*>*)supportedCodecs {
   NSMutableArray<RTCVideoCodecInfo*>* codecs =
       [[super supportedCodecs] mutableCopy];
-#if defined(OWT_USE_H265)
+#if defined(WEBRTC_USE_H265)
   if (@available(iOS 11.0, *)) {
     [codecs addObject:[[RTCVideoCodecInfo alloc]
                           initWithName:kRTCVideoCodecH265Name]];

--- a/talk/owt/sdk/base/objc/OWTDefaultVideoEncoderFactory.m
+++ b/talk/owt/sdk/base/objc/OWTDefaultVideoEncoderFactory.m
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #import "RTCEncodedImage.h"
-#if defined(OWT_USE_H265)
+#if defined(WEBRTC_USE_H265)
 #import "RTCVideoCodecH265.h"
 #endif
 #import "talk/owt/sdk/base/objc/OWTDefaultVideoEncoderFactory.h"
@@ -12,7 +12,7 @@
 + (NSArray<RTCVideoCodecInfo*>*)supportedCodecs {
   NSMutableArray<RTCVideoCodecInfo*>* codecs =
       [[RTCDefaultVideoEncoderFactory supportedCodecs] mutableCopy];
-#if defined(OWT_USE_H265)
+#if defined(WEBRTC_USE_H265)
   if (@available(iOS 11.0, *)) {
     [codecs addObject:[[RTCVideoCodecInfo alloc]
                           initWithName:kRTCVideoCodecH265Name]];
@@ -21,7 +21,7 @@
   return codecs;
 }
 - (id<RTCVideoEncoder>)createEncoder:(RTCVideoCodecInfo*)info {
-#if defined(OWT_USE_H265)
+#if defined(WEBRTC_USE_H265)
   if (@available(iOS 11.0, *)) {
     if ([info.name isEqualToString:kRTCVideoCodecH265Name]) {
       return [[RTCVideoEncoderH265 alloc] initWithCodecInfo:info];

--- a/talk/owt/sdk/base/objc/OWTLocalStream.mm
+++ b/talk/owt/sdk/base/objc/OWTLocalStream.mm
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <string>
 #include <unordered_map>
+#include "RTCLogging.h"
 #import <Foundation/Foundation.h>
 #import "RTCVideoSource.h"
 #import "talk/owt/sdk/base/objc/OWTLocalStream+Private.h"
@@ -147,6 +148,7 @@
   return [NSString stringForStdString:rtc::CreateRandomUuid()];
 }
 - (void)dealloc {
+  RTCLogInfo(@"Dealloc OWTLocalStream.");
   if (_capturer && [_capturer isKindOfClass:[RTCCameraVideoCapturer class]]) {
     RTCCameraVideoCapturer* cameraVideoCapturer =
         (RTCCameraVideoCapturer*)_capturer;

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -335,6 +335,10 @@ PeerConnectionDependencyFactory::PeerConnectionFactory() const {
   return pc_factory_;
 }
 
+rtc::Thread* PeerConnectionDependencyFactory::SignalingThreadForTesting() {
+  return signaling_thread.get();
+}
+
 #if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
 scoped_refptr<webrtc::AudioDeviceModule> PeerConnectionDependencyFactory::
     CreateCustomizedAudioDeviceModuleOnCurrentThread() {

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.h
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.h
@@ -57,6 +57,8 @@ class PeerConnectionDependencyFactory : public rtc::RefCountInterface {
   // Returns current |pc_factory_|.
   rtc::scoped_refptr<PeerConnectionFactoryInterface> PeerConnectionFactory()
       const;
+  // Returns |signaling_thread_| for testing.
+  rtc::Thread* SignalingThreadForTesting();
   ~PeerConnectionDependencyFactory() override;
  protected:
   explicit PeerConnectionDependencyFactory();

--- a/talk/owt/sdk/base/stream.cc
+++ b/talk/owt/sdk/base/stream.cc
@@ -128,6 +128,7 @@ MediaStreamInterface* Stream::MediaStream() const {
   return media_stream_;
 }
 Stream::~Stream() {
+  RTC_LOG(LS_ERROR)<<"~Stream.";
   DetachVideoRenderer();
   DetachAudioPlayer();
   if (media_stream_)
@@ -386,11 +387,9 @@ void Stream::TriggerOnStreamUnmute(TrackKind track_kind) {
 }
 #if !defined(WEBRTC_WIN)
 LocalStream::LocalStream() {}
-#if !defined(WEBRTC_LINUX)
 LocalStream::LocalStream(MediaStreamInterface* media_stream,
                          StreamSourceInfo source)
     : Stream(media_stream, source) {}
-#endif
 #endif
 LocalStream::~LocalStream() {
   RTC_LOG(LS_INFO) << "Destroy LocalCameraStream.";

--- a/talk/owt/sdk/base/win/mediacapabilities.cc
+++ b/talk/owt/sdk/base/win/mediacapabilities.cc
@@ -67,7 +67,7 @@ MediaCapabilities::SupportedCapabilitiesForVideoEncoder(
       }
 #if (MFX_VERSION >= 1027)
       if (platform_code >= MFX_PLATFORM_ICELAKE) {
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
         support_hevc_8 = true;
         support_hevc_10 = true;
 #endif
@@ -139,7 +139,7 @@ MediaCapabilities::SupportedCapabilitiesForVideoEncoder(
             capabilities.push_back(vp9_10_cap);
           }
         }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
         else if (codec == owt::base::VideoCodec::kH265) {
           memset(&video_param, 0, sizeof(video_param));
           // We remove support of SW encoders through plugin, so never
@@ -295,7 +295,7 @@ MediaCapabilities::SupportedCapabilitiesForVideoDecoder(
           capabilities.push_back(avc_cap);
         }
       }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
       else if (codec == owt::base::VideoCodec::kH265) {
         memset(&video_param, 0, sizeof(video_param));
         video_param.mfx.CodecId = MFX_CODEC_HEVC;

--- a/talk/owt/sdk/base/win/msdkvideodecoder.cc
+++ b/talk/owt/sdk/base/win/msdkvideodecoder.cc
@@ -202,7 +202,7 @@ int32_t MSDKVideoDecoder::InitDecodeOnCodecThread() {
     }
     if (codec_.codecType == webrtc::kVideoCodecVP8) {
       codec_id = MFX_CODEC_VP8;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     } else if (codec_.codecType == webrtc::kVideoCodecH265) {
       codec_id = MFX_CODEC_HEVC;
 #endif

--- a/talk/owt/sdk/base/win/msdkvideodecoderfactory.cc
+++ b/talk/owt/sdk/base/win/msdkvideodecoderfactory.cc
@@ -23,7 +23,7 @@ MSDKVideoDecoderFactory::MSDKVideoDecoderFactory() {
 
   bool is_vp8_hw_supported = false, is_vp9_hw_supported = false;
   bool is_h264_hw_supported = false, is_av1_hw_supported = false;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 // TODO: Add logic to detect plugin by MSDK.
   bool is_h265_hw_supported = true;
 #endif
@@ -32,7 +32,7 @@ MSDKVideoDecoderFactory::MSDKVideoDecoderFactory() {
   std::vector<owt::base::VideoCodec> codecs_to_check;
   codecs_to_check.push_back(owt::base::VideoCodec::kH264);
   codecs_to_check.push_back(owt::base::VideoCodec::kVp9);
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   codecs_to_check.push_back(owt::base::VideoCodec::kH265);
 #endif
   codecs_to_check.push_back(owt::base::VideoCodec::kAv1);
@@ -54,7 +54,7 @@ MSDKVideoDecoderFactory::MSDKVideoDecoderFactory() {
       is_av1_hw_supported = true;
       supported_codec_types_.push_back(webrtc::kVideoCodecAV1);
     }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     else if (capability.codec_type == owt::base::VideoCodec::kH265 && !is_h265_hw_supported) {
       is_h265_hw_supported = true;
       supported_codec_types_.push_back(webrtc::kVideoCodecH265);
@@ -68,7 +68,7 @@ MSDKVideoDecoderFactory::~MSDKVideoDecoderFactory() {}
 std::unique_ptr<webrtc::VideoDecoder> MSDKVideoDecoderFactory::CreateVideoDecoder(
     const webrtc::SdpVideoFormat& format) {
   bool vp9_hw = false, vp8_hw = false, av1_hw = false, h264_hw = false;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   bool h265_hw = false;
 #endif
   for (auto& codec : supported_codec_types_) {
@@ -80,7 +80,7 @@ std::unique_ptr<webrtc::VideoDecoder> MSDKVideoDecoderFactory::CreateVideoDecode
       vp8_hw = true;
     else if (codec == webrtc::kVideoCodecVP9)
       vp9_hw = true;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     else if (codec == webrtc::kVideoCodecH265) {
       h265_hw = true;
       RTC_LOG(LS_ERROR) << "Enabling hardware hevc.";
@@ -99,7 +99,7 @@ std::unique_ptr<webrtc::VideoDecoder> MSDKVideoDecoderFactory::CreateVideoDecode
              !av1_hw) {
     return webrtc::CreateLibaomAv1Decoder();
   } 
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   // This should not happen. We do not return here but preceed with HW decoder.
   else if (absl::EqualsIgnoreCase(format.name, cricket::kH265CodecName) && !h265_hw) {
     RTC_LOG(LS_ERROR) << "Returning null hevc encoder.";
@@ -120,7 +120,7 @@ std::unique_ptr<webrtc::VideoDecoder> MSDKVideoDecoderFactory::CreateVideoDecode
   if (webrtc::kIsLibaomAv1DecoderSupported) {
     supported_codecs.push_back(webrtc::SdpVideoFormat(cricket::kAv1CodecName));
   }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   for (const webrtc::SdpVideoFormat& format : CodecUtils::GetSupportedH265Codecs()) {
     supported_codecs.push_back(format);
   }

--- a/talk/owt/sdk/base/win/msdkvideoencoder.cc
+++ b/talk/owt/sdk/base/win/msdkvideoencoder.cc
@@ -13,7 +13,7 @@
 #include "talk/owt/sdk/base/win/msdkvideoencoder.h"
 #include "webrtc/modules/video_coding/codecs/vp9/include/vp9_globals.h"
 #include "webrtc/common_video/h264/h264_common.h"
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
 #include "webrtc/common_video/h265/h265_common.h"
 #endif
 #include "webrtc/media/base/vp9_profile.h"
@@ -197,7 +197,7 @@ int MSDKVideoEncoder::InitEncodeOnEncoderThread(
     case webrtc::kVideoCodecH264:
       codec_id = MFX_CODEC_AVC;
       break;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     case webrtc::kVideoCodecH265:
       codec_id = MFX_CODEC_HEVC;
       break;

--- a/talk/owt/sdk/base/win/msdkvideoencoderfactory.cc
+++ b/talk/owt/sdk/base/win/msdkvideoencoderfactory.cc
@@ -23,7 +23,7 @@ MSDKVideoEncoderFactory::MSDKVideoEncoderFactory() {
   std::vector<owt::base::VideoCodec> codecs_to_check;
   codecs_to_check.push_back(owt::base::VideoCodec::kH264);
   codecs_to_check.push_back(owt::base::VideoCodec::kVp9);
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   codecs_to_check.push_back(owt::base::VideoCodec::kH265);
 #endif
   codecs_to_check.push_back(owt::base::VideoCodec::kAv1);
@@ -34,7 +34,7 @@ MSDKVideoEncoderFactory::MSDKVideoEncoderFactory() {
   supported_codec_types_.push_back(webrtc::kVideoCodecH264);
   supported_codec_types_.push_back(webrtc::kVideoCodecVP9);
   supported_codec_types_.push_back(webrtc::kVideoCodecVP8);
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   supported_codec_types_.push_back(webrtc::kVideoCodecH265);
 #endif
   supported_codec_types_.push_back(webrtc::kVideoCodecAV1);
@@ -43,7 +43,7 @@ MSDKVideoEncoderFactory::MSDKVideoEncoderFactory() {
 std::unique_ptr<webrtc::VideoEncoder> MSDKVideoEncoderFactory::CreateVideoEncoder(
     const webrtc::SdpVideoFormat& format) {
   bool vp9_hw = false, vp8_hw = false, av1_hw = false, h264_hw = false;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   bool h265_hw = false;
 #endif
   for (auto& codec : supported_codec_types_) {
@@ -55,7 +55,7 @@ std::unique_ptr<webrtc::VideoEncoder> MSDKVideoEncoderFactory::CreateVideoEncode
       vp8_hw = true;
     else if (codec == webrtc::kVideoCodecVP9)
       vp9_hw = true;
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
     else if (codec == webrtc::kVideoCodecH265)
       h265_hw = true;
 #endif
@@ -69,7 +69,7 @@ std::unique_ptr<webrtc::VideoEncoder> MSDKVideoEncoderFactory::CreateVideoEncode
   // TODO: Replace with AV1 HW encoder post ADL.
   else if (absl::EqualsIgnoreCase(format.name, cricket::kAv1CodecName))
     return webrtc::CreateLibaomAv1Encoder();
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   else if (absl::EqualsIgnoreCase(format.name, cricket::kH265CodecName) &&
            !h265_hw) {
   }
@@ -90,7 +90,7 @@ MSDKVideoEncoderFactory::GetSupportedFormats() const {
   if (webrtc::kIsLibaomAv1EncoderSupported) {
     supported_codecs.push_back(webrtc::SdpVideoFormat(cricket::kAv1CodecName));
   }
-#ifndef DISABLE_H265
+#ifdef WEBRTC_USE_H265
   for (const webrtc::SdpVideoFormat& format : CodecUtils::GetSupportedH265Codecs()) {
     supported_codecs.push_back(format);
   }

--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -264,9 +264,7 @@ class LocalStream : public Stream {
  public:
 #if !defined(WEBRTC_WIN)
   LocalStream();
-#if !defined(WEBRTC_LINUX)
   LocalStream(MediaStreamInterface* media_stream, StreamSourceInfo source);
-#endif
 #endif
   virtual ~LocalStream();
   using Stream::Attributes;

--- a/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
+++ b/talk/owt/sdk/p2p/p2ppeerconnectionchannel.cc
@@ -1153,6 +1153,7 @@ void P2PPeerConnectionChannel::DrainPendingStreams() {
     OnNegotiationNeeded();
   }
 }
+
 void P2PPeerConnectionChannel::SendStop(
     std::function<void()> on_success,
     std::function<void(std::unique_ptr<Exception>)> on_failure) {
@@ -1161,6 +1162,7 @@ void P2PPeerConnectionChannel::SendStop(
   json[kMessageTypeKey] = kChatClosed;
   SendSignalingMessage(json, on_success, on_failure);
 }
+
 void P2PPeerConnectionChannel::ClosePeerConnection() {
   RTC_LOG(LS_INFO) << "Close peer connection.";
   if (peer_connection_) {

--- a/talk/owt/sdk/p2p/tests/BUILD.gn
+++ b/talk/owt/sdk/p2p/tests/BUILD.gn
@@ -7,12 +7,13 @@ rtc_test("p2p_e2e_test") {
     "e2e_tests.cc",
     "fake_signaling_channel.cc",
   ]
-  include_dirs = [ "//talk/owt/sdk/include/cpp" ]
+  include_dirs = [ "//talk/owt/sdk/include/cpp","//third_party" ]
   deps = [
     "../../..:owt_sdk_p2p",
     "//third_party/webrtc/test:run_loop",
     "//third_party/webrtc/test:test_main",
     "//third_party/webrtc/test:test_support",
+    "//third_party/webrtc/test:video_test_support",
   ]
   if (is_win) {
     libs = [ "dcomp.lib" ]

--- a/talk/owt/sdk/p2p/tests/e2e_tests.cc
+++ b/talk/owt/sdk/p2p/tests/e2e_tests.cc
@@ -2,14 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "owt/base/videorendererinterface.h"
+#include "talk/owt/sdk/base/peerconnectiondependencyfactory.h"
 #include "owt/p2p/p2pclient.h"
 #include "talk/owt/sdk/p2p/tests/fake_signaling_channel.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/webrtc/api/task_queue/default_task_queue_factory.h"
+#include "third_party/webrtc/api/video/i420_buffer.h"
+#include "third_party/webrtc/pc/test/frame_generator_capturer_video_track_source.h"
 #include "third_party/webrtc/rtc_base/checks.h"
 #include "third_party/webrtc/rtc_base/logging.h"
 #include "third_party/webrtc/test/run_loop.h"
+#include "third_party/webrtc/test/testsupport/frame_writer.h"
 
 namespace owt {
 namespace p2p {
@@ -20,6 +25,76 @@ using namespace owt::p2p;
 class P2PClientMockObserver : public owt::p2p::P2PClientObserver {
  public:
   MOCK_METHOD2(OnMessageReceived, void(const std::string&, const std::string));
+  MOCK_METHOD1(OnStreamAdded,
+               void(std::shared_ptr<owt::base::RemoteStream> stream));
+};
+
+// A sink dumps video frames in a given interval.
+class VideoDumpSink : public owt::base::VideoRendererInterface {
+ public:
+  // If `runloop` is not nullptr, it'll quit after receving `quit_after` frames.
+  VideoDumpSink(const std::string& output_filename,
+                uint32_t interval,
+                webrtc::test::RunLoop* runloop,
+                uint32_t quit_after)
+      : output_filename_(output_filename),
+        interval_(interval),
+        to_be_skipped_(0),
+        runloop_(runloop),
+        max_frames_(quit_after),
+        frame_received_(0) {}
+  void RenderFrame(std::unique_ptr<VideoBuffer> buffer) {
+    if (to_be_skipped_ == 0) {
+      webrtc::test::JpegFrameWriter frame_writer(output_filename_);
+      rtc::scoped_refptr<webrtc::I420Buffer> image_buffer =
+          webrtc::I420Buffer::Copy(
+              buffer->resolution.width, buffer->resolution.height,
+              buffer->buffer, buffer->resolution.width,
+              buffer->buffer +
+                  buffer->resolution.width * buffer->resolution.height,
+              buffer->resolution.width / 2,
+              buffer->buffer +
+                  (buffer->resolution.width * buffer->resolution.height) / 4 *
+                      5,
+              buffer->resolution.width / 2);
+      frame_writer.WriteFrame(
+          webrtc::VideoFrame(
+              image_buffer, webrtc::VideoRotation::kVideoRotation_0,
+              webrtc::Clock::GetRealTimeClock()->TimeInMilliseconds()),
+          100);
+      to_be_skipped_ = interval_;
+    } else {
+      to_be_skipped_ += 1;
+    }
+    if (runloop_ && ++frame_received_ >= max_frames_) {
+      RTC_LOG(LS_INFO)<<"Quit the runloop.";
+      runloop_->Quit();
+    }
+  }
+  // Render type that indicates the VideoBufferType the renderer would receive.
+  VideoRendererType Type() override { return VideoRendererType::kI420; }
+
+ private:
+  const std::string output_filename_;
+  uint32_t interval_;
+  uint32_t to_be_skipped_;
+  webrtc::test::RunLoop* runloop_;
+  uint32_t max_frames_;
+  uint32_t frame_received_;
+};
+
+class StreamDumpObserver : public owt::p2p::P2PClientObserver {
+ public:
+  StreamDumpObserver(VideoDumpSink* video_sink) : video_sink_(video_sink) {
+    RTC_CHECK(video_sink);
+  }
+  void OnStreamAdded(std::shared_ptr<owt::base::RemoteStream> stream) override {
+    RTC_LOG(LS_INFO) << "OnStreamAdded";
+    stream->AttachVideoRenderer(*video_sink_);
+  }
+
+ private:
+  VideoDumpSink* video_sink_;
 };
 
 class EndToEndTest : public ::testing::Test {
@@ -66,11 +141,47 @@ class EndToEndTest : public ::testing::Test {
   webrtc::test::RunLoop loop_;
 };
 
-TEST_F(EndToEndTest, SendMessgeCanBeReceived) {
-  task_queue_->PostTask([this] {
-    client1_->Send("client2", "message", nullptr, nullptr);
-    EXPECT_CALL(observer2_, OnMessageReceived("client1", testing::_))
-        .WillOnce(testing::InvokeWithoutArgs([this] { loop_.Quit(); }));
+// TEST_F(EndToEndTest, SendMessgeCanBeReceived) {
+//   task_queue_->PostTask([this] {
+//     client1_->Send("client2", "message", nullptr, nullptr);
+//     EXPECT_CALL(observer2_, OnMessageReceived("client1", testing::_))
+//         .WillOnce(testing::InvokeWithoutArgs([this] { loop_.Quit(); }));
+//   });
+//   loop_.Run();
+// }
+
+rtc::scoped_refptr<MediaStreamInterface> CreateFakeMediaStream() {
+  auto* pcdf = owt::base::PeerConnectionDependencyFactory::Get();
+  rtc::scoped_refptr<MediaStreamInterface> media_stream =
+      pcdf->CreateLocalMediaStream("fake-media-stream");
+  auto source_config = webrtc::FrameGeneratorCapturerVideoTrackSource::Config();
+  source_config.num_squares_generated = 3;
+  rtc::scoped_refptr<webrtc::FrameGeneratorCapturerVideoTrackSource>
+      video_track_source =
+          pcdf->SignalingThreadForTesting()->BlockingCall([&source_config] {
+            rtc::scoped_refptr<webrtc::FrameGeneratorCapturerVideoTrackSource>
+                source = rtc::make_ref_counted<
+                    webrtc::FrameGeneratorCapturerVideoTrackSource>(
+                    source_config, webrtc::Clock::GetRealTimeClock(), false);
+            source->Start();
+            return source;
+          });
+  rtc::scoped_refptr<webrtc::VideoTrackInterface> video_track =
+      pcdf->CreateLocalVideoTrack("fake-video-track", video_track_source.get());
+  media_stream->AddTrack(video_track);
+  return media_stream;
+}
+
+TEST_F(EndToEndTest, VideoCall) {
+  std::shared_ptr<owt::base::LocalStream> stream =
+      std::make_shared<owt::base::LocalStream>(CreateFakeMediaStream().get(),
+                                               StreamSourceInfo());
+  VideoDumpSink sink("video_dump.jpg", 10, &loop_, 30);
+  StreamDumpObserver observer(&sink);
+  client2_->AddObserver(observer);
+
+  task_queue_->PostTask([this, stream] {
+    client1_->Publish("client2", stream, nullptr, nullptr);
   });
   loop_.Run();
 }


### PR DESCRIPTION
This change enables HEVC support after rebasing to M108. HEVC related structures are always declared, but the codec is only implemented when GN arg rtc_use_h265 is enabled (macro WEBRTC_USE_H265 is defined).