### PR TITLE
Enable C++20.

### DIFF
--- a/scripts/prepare_dev.py
+++ b/scripts/prepare_dev.py
@@ -47,7 +47,10 @@ patchList = [
     ('0015-Remove-custom-d8-dependency.patch', BUILD_PATH),
     ('0016-Remove-deprecated-create_srcjar-property.patch', THIRD_PARTY_PATH),
     ('0017-Build-libvpx-with-RTC-rate-control-impl-included.patch', THIRD_PARTY_PATH),
-    ('0018-Patch-ffmpeg-to-address-security-issues.patch', FFMPEG_PATH)
+    ('0018-Patch-ffmpeg-to-address-security-issues.patch', FFMPEG_PATH),
+    ('0019-Enable-C-20-on-iOS.patch', BUILD_PATH),
+    ('0020-Enable-C-20-for-all-platforms-but-LaCrOS-and-Fuchsia.patch', BUILD_PATH),
+    ('0021-Allow-third-party-repositories-to-disable-C-20-for-M.patch', BUILD_PATH)
 ]
 
 def _patch(ignoreFailures=False):

--- a/talk/owt/patches/0019-Enable-C-20-on-iOS.patch
+++ b/talk/owt/patches/0019-Enable-C-20-on-iOS.patch
@@ -1,0 +1,38 @@
+From c1c8b1bec9b28039af31b50f09e2b255efe55a68 Mon Sep 17 00:00:00 2001
+From: Tiago Vignatti <tvignatti@igalia.com>
+Date: Fri, 14 Oct 2022 23:34:50 +0000
+Subject: [PATCH 1/3] Enable C++20 on iOS
+
+Doing this in advance of enabling for more platforms allows monitoring
+compile-time effects with less chance of adversely affecting the CQ,
+while still getting the benefit of breaking a bot if someone lands a
+change that breaks the build only in C++20.
+
+Bug: 1284275
+Change-Id: I0cd05cd13c94f7f597b8c39506f9a9a7f2de463a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3953137
+Reviewed-by: Nico Weber <thakis@chromium.org>
+Commit-Queue: Peter Kasting <pkasting@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1059534}
+NOKEYCHECK=True
+GitOrigin-RevId: 47957c127966524755025f10a7d49e5c0619fdec
+---
+ config/compiler/BUILD.gn | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
+index 9b1e68be0..0f7cdade3 100644
+--- a/config/compiler/BUILD.gn
++++ b/config/compiler/BUILD.gn
+@@ -611,7 +611,7 @@ config("compiler") {
+     # turned off we need the !is_nacl clause and the (is_nacl && is_clang)
+     # clause, above.
+     cflags_c += [ "-std=c11" ]
+-    if (is_mac) {
++    if (is_apple) {
+       # TODO(crbug.com/1284275): Switch to C++20 on all platforms.
+       cflags_cc += [ "-std=c++20" ]
+     } else {
+-- 
+2.37.1.windows.1
+

--- a/talk/owt/patches/0020-Enable-C-20-for-all-platforms-but-LaCrOS-and-Fuchsia.patch
+++ b/talk/owt/patches/0020-Enable-C-20-for-all-platforms-but-LaCrOS-and-Fuchsia.patch
@@ -1,0 +1,83 @@
+From fb5d93779895575442a1ec4acdaf391145cd253a Mon Sep 17 00:00:00 2001
+From: Peter Kasting <pkasting@chromium.org>
+Date: Fri, 21 Oct 2022 23:33:10 +0000
+Subject: [PATCH 2/3] Enable C++20 for all platforms but LaCrOS and Fuchsia.
+
+This increases the APK size by ~0.2% on Android, which is due to a
+host of small inlinining losses around the codebase. Looking into
+these more, I suspect many are due to increased inlining of things
+like vector methods in constructors/destructors (vector has become
+constexpr). It's not clear we can avoid this except by filing targeted
+bugs against Clang/libc++ for bad heuristics.
+
+Bug: 1284275
+Change-Id: Iff7f04eac9b4af09bb9239b80f9a5c8ce929f329
+Binary-Size: Size increase is unavoidable (see above).
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3946562
+Commit-Queue: Peter Kasting <pkasting@chromium.org>
+Reviewed-by: Andrew Grieve <agrieve@chromium.org>
+Reviewed-by: Danil Chapovalov <danilchap@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1062405}
+NOKEYCHECK=True
+GitOrigin-RevId: 4d6e6bbfa187c2adfdf5d89cdb54e25e1528c308
+---
+ config/compiler/BUILD.gn | 29 ++++++++++++++++-------------
+ 1 file changed, 16 insertions(+), 13 deletions(-)
+
+diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
+index 0f7cdade3..7acf31b37 100644
+--- a/config/compiler/BUILD.gn
++++ b/config/compiler/BUILD.gn
+@@ -589,21 +589,22 @@ config("compiler") {
+       if (is_clang) {
+         cflags_cc += [ "-fno-trigraphs" ]
+       }
+-    } else if (is_linux) {
+-      # TODO(crbug.com/1284275): Switch to C++20 on all platforms.
+-      if (is_clang) {
+-        cflags_cc += [ "-std=${standard_prefix}++20" ]
++    } else if (is_clang) {
++      if (is_chromeos_lacros) {
++        # TODO(crbug.com/1376742): LaCrOS currently triggers a strange DCHECK
++        # failure in C++20 mode. Switch to C++20 when this is resolved.
++        cflags_cc += [ "-std=${standard_prefix}++17" ]
+       } else {
+-        # The gcc bots are currently using GCC 9, which is not new enough to
+-        # support "c++20"/"gnu++20".
+-        cflags_cc += [ "-std=${standard_prefix}++2a" ]
++        cflags_cc += [ "-std=${standard_prefix}++20" ]
+       }
+     } else {
+-      cflags_cc += [ "-std=${standard_prefix}++17" ]
++      # The gcc bots are currently using GCC 9, which is not new enough to
++      # support "c++20"/"gnu++20".
++      cflags_cc += [ "-std=${standard_prefix}++2a" ]
+     }
+   } else if (is_win) {
+     cflags_c += [ "/std:c11" ]
+-    cflags_cc += [ "/std:c++17" ]
++    cflags_cc += [ "/std:c++20" ]
+   } else if (!is_nacl) {
+     # TODO(mcgrathr) - the NaCl GCC toolchain doesn't support either
+     # gnu11/gnu++11 or c11/c++11; we technically don't need this toolchain any
+@@ -611,11 +612,13 @@ config("compiler") {
+     # turned off we need the !is_nacl clause and the (is_nacl && is_clang)
+     # clause, above.
+     cflags_c += [ "-std=c11" ]
+-    if (is_apple) {
+-      # TODO(crbug.com/1284275): Switch to C++20 on all platforms.
+-      cflags_cc += [ "-std=c++20" ]
+-    } else {
++
++    if (is_fuchsia) {
++      # TODO(crbug.com/fuchsia/108751): The FIDL compiler generates code that
++      # will not compile in C++20 mode. Switch to C++20 when this is resolved.
+       cflags_cc += [ "-std=c++17" ]
++    } else {
++      cflags_cc += [ "-std=c++20" ]
+     }
+   }
+ 
+-- 
+2.37.1.windows.1
+

--- a/talk/owt/patches/0021-Allow-third-party-repositories-to-disable-C-20-for-M.patch
+++ b/talk/owt/patches/0021-Allow-third-party-repositories-to-disable-C-20-for-M.patch
@@ -1,0 +1,42 @@
+From 027e2a133fd06829705b474f8f983302187953ea Mon Sep 17 00:00:00 2001
+From: Yuly Novikov <ynovikov@chromium.org>
+Date: Wed, 2 Nov 2022 17:00:51 +0000
+Subject: [PATCH 3/3] Allow third-party repositories to disable C++20 for MSVC
+
+For example, some ANGLE targets fail to compile with MSVC and C++20,
+so allow to use C++17 instead.
+
+Bug: 1284275, 1380553, 1380455
+Change-Id: Ib60a25fe60b5fd98506264cf1dc970d731367776
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3997254
+Auto-Submit: Yuly Novikov <ynovikov@chromium.org>
+Reviewed-by: Peter Kasting <pkasting@chromium.org>
+Reviewed-by: Bruce Dawson <brucedawson@chromium.org>
+Commit-Queue: Bruce Dawson <brucedawson@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1066541}
+NOKEYCHECK=True
+GitOrigin-RevId: 2c98c5af6539d7ffc10fbe83d3e76216b7e01186
+---
+ config/compiler/BUILD.gn | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
+index 7acf31b37..75e3de46f 100644
+--- a/config/compiler/BUILD.gn
++++ b/config/compiler/BUILD.gn
+@@ -604,7 +604,11 @@ config("compiler") {
+     }
+   } else if (is_win) {
+     cflags_c += [ "/std:c11" ]
+-    cflags_cc += [ "/std:c++20" ]
++    if (!is_clang && defined(msvc_use_cxx17) && msvc_use_cxx17) {
++      cflags_cc += [ "/std:c++17" ]
++    } else {
++      cflags_cc += [ "/std:c++20" ]
++    }
+   } else if (!is_nacl) {
+     # TODO(mcgrathr) - the NaCl GCC toolchain doesn't support either
+     # gnu11/gnu++11 or c11/c++11; we technically don't need this toolchain any
+-- 
+2.37.1.windows.1
+


### PR DESCRIPTION
Some code requires C++20 features, like designated initializers. When build with MSVC, `/std:c++20` should be specified explicitly for some targets.