### PR TITLE
Build complete lib for OWT SDK.

### DIFF
--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import("//build/config/sysroot.gni")
 import("//build_overrides/webrtc.gni")
 import("//testing/test.gni")
 
@@ -101,6 +102,7 @@ if (!is_ios) {
         "//third_party/webrtc:webrtc",
         "//third_party/webrtc/api:libjingle_peerconnection_api",
       ]
+      complete_static_lib = true
     }
   }
 }
@@ -338,7 +340,7 @@ static_library("owt_sdk_base") {
       "sdk/base/customizedaudiodevicemodule.h",
     ]
   }
-  if (is_linux) {
+  if (is_linux && use_sysroot) {
     configs += [ "//third_party/webrtc/modules/desktop_capture:gio" ]
   }
   if (is_clang) {


### PR DESCRIPTION
This change also fixes a build error for GCC. `//third_party/webrtc/modules/desktop_capture:gio` is only defined when `rtc_use_pipewire` is `true`, and `rtc_use_pipewire` is `true` only when `use_sysroot` is `true`.