### PR TITLE
Export symbols for public APIs.

### DIFF
--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -57,6 +57,13 @@ if (is_android) {
   }
 }
 
+config("owt_symbols") {
+  defines = [ "OWT_LIBRARY_IMPL" ]
+  if (is_component_build) {
+    defines += [ "OWT_ENABLE_SYMBOL_EXPORT" ]
+  }
+}
+
 static_library("owt_deps") {
   deps = [
     "//third_party/webrtc/api:create_peerconnection_factory",
@@ -86,11 +93,6 @@ if (!is_ios) {
       if (rtc_enable_protobuf) {
         deps += [ "//third_party/protobuf:protobuf_lite" ]
       }
-
-      if (rtc_enable_protobuf) {
-        deps += [ "//third_party/protobuf:protobuf_lite" ]
-      }
-      complete_static_lib = true
     }
   } else {
     static_library("owt") {
@@ -164,6 +166,8 @@ static_library("owt_sdk_base") {
       "sdk/base/customizedvideoencoderproxy.h",
       "sdk/base/customizedvideosource.cc",
       "sdk/base/customizedvideosource.h",
+      "sdk/base/desktopcapturer.cc",
+      "sdk/base/desktopcapturer.h",
       "sdk/base/webrtcvideorendererimpl.cc",
       "sdk/base/webrtcvideorendererimpl.h",
       "sdk/base/windowcapturer.cc",
@@ -200,6 +204,8 @@ static_library("owt_sdk_base") {
     "sdk/include/cpp",
     "//third_party",
   ]
+
+  configs += [ ":owt_symbols" ]
 
   defines = [ "USE_BUILTIN_SW_CODECS" ]
 
@@ -261,8 +267,6 @@ static_library("owt_sdk_base") {
   }
   if (is_win) {
     sources += [
-      "sdk/base/desktopcapturer.cc",
-      "sdk/base/desktopcapturer.h",
       "sdk/base/win/d3d11_manager.h",
       "sdk/base/win/device_info_mf.cc",
       "sdk/base/win/device_info_mf.h",
@@ -380,6 +384,7 @@ static_library("owt_sdk_p2p") {
   if (is_clang) {
     configs -= [ "//build/config/clang:find_bad_constructs" ]
   }
+  configs += [ ":owt_symbols" ]
 }
 static_library("owt_sdk_conf") {
   deps = [

--- a/talk/owt/sdk/include/cpp/owt/base/audioplayerinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/audioplayerinterface.h
@@ -5,10 +5,12 @@
 #ifndef OWT_BASE_AUDIOPLAYERINTERFACE_H_
 #define OWT_BASE_AUDIOPLAYERINTERFACE_H_
 
+#include "owt/base/export.h"
+
 namespace owt {
 namespace base {
 /// Interface for rendering PCM data in a stream
-class AudioPlayerInterface {
+class OWT_EXPORT AudioPlayerInterface {
  public:
   /// Passes audio buffer to audio player.
   virtual void OnData(const void* audio_data,

--- a/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/clientconfiguration.h
@@ -3,14 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_CLIENTCONFIGURATION_H_
 #define OWT_BASE_CLIENTCONFIGURATION_H_
+
 #include <vector>
 #include <string>
 #include "owt/base/commontypes.h"
 #include "owt/base/network.h"
+#include "owt/base/export.h"
+
 namespace owt {
 namespace base{
 /// Client configurations
-struct ClientConfiguration {
+struct OWT_EXPORT ClientConfiguration {
   enum class CandidateNetworkPolicy : int { kAll = 1, kLowCost };
   ClientConfiguration()
        : candidate_network_policy(CandidateNetworkPolicy::kAll) {}

--- a/talk/owt/sdk/include/cpp/owt/base/clock.h
+++ b/talk/owt/sdk/include/cpp/owt/base/clock.h
@@ -5,6 +5,7 @@
 #define OWT_BASE_CLOCK_H_
 
 #include <stdint.h>
+#include "owt/base/export.h"
 
 namespace webrtc {
 class Clock;
@@ -14,7 +15,7 @@ namespace owt {
 namespace base {
 
 /// A Wrapper of webrtc::Clock.
-class Clock {
+class OWT_EXPORT Clock {
  public:
   explicit Clock();
   int64_t TimeInMilliseconds();

--- a/talk/owt/sdk/include/cpp/owt/base/commontypes.h
+++ b/talk/owt/sdk/include/cpp/owt/base/commontypes.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "owt/base/export.h"
 namespace owt {
 namespace base {
 
@@ -50,7 +51,7 @@ enum class NetworkPriority : int {
   kDefault
 };
 /// This class represents a resolution value.
-struct Resolution {
+struct OWT_EXPORT Resolution {
   /// Construct an instance with width and height equal to 0.
   explicit Resolution() : width(0), height(0) {}
   /// Construct an instance with specify width and height.
@@ -63,7 +64,7 @@ struct Resolution {
 };
 
 /// This class represents a camera capability.
-struct VideoTrackCapabilities {
+struct OWT_EXPORT VideoTrackCapabilities {
   /// Construct an instance with width and height equal to 0.
   explicit VideoTrackCapabilities() : width(0), height(0), frameRate(0) {}
   /// Construct an instance with specify width and height.
@@ -79,7 +80,7 @@ struct VideoTrackCapabilities {
 };
 
 /// Audio codec parameters for an audio track.
-struct AudioCodecParameters {
+struct OWT_EXPORT AudioCodecParameters {
   /// Construct an instance of AudioCodecParameters with default param.
   AudioCodecParameters()
       : name(AudioCodec::kUnknown), channel_count(0), clock_rate(0) {}
@@ -97,7 +98,7 @@ struct AudioCodecParameters {
 };
 
 /// RTP endoding settings for a stream
-struct RtpEncodingParameters {
+struct OWT_EXPORT RtpEncodingParameters {
   // number of temporal layers requested to encoder, if supported.
   int num_temporal_layers = 1;
 
@@ -129,7 +130,7 @@ struct RtpEncodingParameters {
 };
 
 /// Audio encoding parameters.
-struct AudioEncodingParameters {
+struct OWT_EXPORT AudioEncodingParameters {
   explicit AudioEncodingParameters();
   AudioEncodingParameters(const AudioCodecParameters& codec_param,
                           unsigned long bitrate_bps);
@@ -140,7 +141,7 @@ struct AudioEncodingParameters {
   unsigned long max_bitrate;
 };
 /// Video codec parameters for a video track.
-struct VideoCodecParameters {
+struct OWT_EXPORT VideoCodecParameters {
   /// Construct an instance of VideoCodecParameters with default parameters.
   explicit VideoCodecParameters();
   /// Construct an instance of VideoCodecParameter with codec name and profile.
@@ -152,7 +153,7 @@ struct VideoCodecParameters {
 
 /// Video encoding parameters. Used to specify the video encoding settings when
 /// publishing the video.
-struct VideoEncodingParameters {
+struct OWT_EXPORT VideoEncodingParameters {
   explicit VideoEncodingParameters();
   /// Construct an instance of VideoEncodingParameters
   VideoEncodingParameters(const VideoCodecParameters& codec_param,
@@ -200,7 +201,7 @@ enum class TransportType : int {
   kUnknown = 99
 };
 /// TransportContraints
-struct TransportConstraints {
+struct OWT_EXPORT TransportConstraints {
   explicit TransportConstraints()
       : type(TransportType::kWebRTC) {}
 
@@ -208,7 +209,7 @@ struct TransportConstraints {
 };
 #endif
 /// Stream source.
-struct StreamSourceInfo {
+struct OWT_EXPORT StreamSourceInfo {
   explicit StreamSourceInfo()
     : audio(AudioSourceInfo::kUnknown),
       video(VideoSourceInfo::kUnknown)
@@ -236,7 +237,7 @@ struct StreamSourceInfo {
   DataSourceInfo data;
 #endif
 };
-struct EnumClassHash {
+struct OWT_EXPORT EnumClassHash {
   template <typename T>
   std::size_t operator()(T t) const {
     return static_cast<std::size_t>(t);

--- a/talk/owt/sdk/include/cpp/owt/base/connectionstats.h
+++ b/talk/owt/sdk/include/cpp/owt/base/connectionstats.h
@@ -3,20 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_CONNECTIONSTATS_H_
 #define OWT_BASE_CONNECTIONSTATS_H_
+
 #include <chrono>
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 #include "owt/base/commontypes.h"
+#include "owt/base/export.h"
 #include "owt/base/network.h"
+
 namespace owt {
 namespace base {
-
-
 // RTC-spec compliant statistics interfaces.
 // https://w3c.github.io/webrtc-pc/#idl-def-rtcdatachannelstate
-struct RTCDataChannelState {
+struct OWT_EXPORT RTCDataChannelState {
   static const char* const kConnecting;
   static const char* const kOpen;
   static const char* const kClosing;
@@ -24,7 +25,7 @@ struct RTCDataChannelState {
 };
 
 // https://w3c.github.io/webrtc-stats/#dom-rtcstatsicecandidatepairstate
-struct RTCStatsIceCandidatePairState {
+struct OWT_EXPORT RTCStatsIceCandidatePairState {
   static const char* const kFrozen;
   static const char* const kWaiting;
   static const char* const kInProgress;
@@ -33,7 +34,7 @@ struct RTCStatsIceCandidatePairState {
 };
 
 // https://w3c.github.io/webrtc-pc/#rtcicecandidatetype-enum
-struct RTCIceCandidateType {
+struct OWT_EXPORT RTCIceCandidateType {
   static const char* const kHost;
   static const char* const kSrflx;
   static const char* const kPrflx;
@@ -41,7 +42,7 @@ struct RTCIceCandidateType {
 };
 
 // https://w3c.github.io/webrtc-pc/#idl-def-rtcdtlstransportstate
-struct RTCDtlsTransportState {
+struct OWT_EXPORT RTCDtlsTransportState {
   static const char* const kNew;
   static const char* const kConnecting;
   static const char* const kConnected;
@@ -52,13 +53,13 @@ struct RTCDtlsTransportState {
 // |RTCMediaStreamTrackStats::kind| is not an enum in the spec but the only
 // valid values are "audio" and "video".
 // https://w3c.github.io/webrtc-stats/#dom-rtcmediastreamtrackstats-kind
-struct RTCMediaStreamTrackKind {
+struct OWT_EXPORT RTCMediaStreamTrackKind {
   static const char* const kAudio;
   static const char* const kVideo;
 };
 
 // https://w3c.github.io/webrtc-stats/#dom-rtcnetworktype
-struct RTCNetworkType {
+struct OWT_EXPORT RTCNetworkType {
   static const char* const kBluetooth;
   static const char* const kCellular;
   static const char* const kEthernet;
@@ -69,7 +70,7 @@ struct RTCNetworkType {
 };
 
 // https://w3c.github.io/webrtc-stats/#dom-rtcqualitylimitationreason
-struct RTCQualityLimitationReason {
+struct OWT_EXPORT RTCQualityLimitationReason {
   static const char* const kNone;
   static const char* const kCpu;
   static const char* const kBandwidth;
@@ -77,7 +78,7 @@ struct RTCQualityLimitationReason {
 };
 
 // https://webrtc.org/experiments/rtp-hdrext/video-content-type/
-struct RTCContentType {
+struct OWT_EXPORT RTCContentType {
   static const char* const kUnspecified;
   static const char* const kScreenshare;
 };
@@ -85,7 +86,7 @@ struct RTCContentType {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#rtcstatstype-str*
  */
-struct RTCStatsType {
+struct OWT_EXPORT RTCStatsType {
   static const char* const kCodec;
   static const char* const kInboundRTP;
   static const char* const kOutboundRTP;
@@ -112,7 +113,7 @@ struct RTCStatsType {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#idl-def-rtcstats*
  */
-class RTCStats {
+class OWT_EXPORT RTCStats {
  public:
   RTCStats(const std::string& type, const std::string& id, int64_t timestamp_us)
       : type(type), id(id), timestamp_us(timestamp_us) {}
@@ -135,14 +136,14 @@ class RTCStats {
   int64_t timestamp_us;
 };
 
-class RTCStatsReport {
+class OWT_EXPORT RTCStatsReport {
  public:
   RTCStatsReport() {}
   virtual ~RTCStatsReport() {}
   typedef std::map<std::string, std::unique_ptr<const owt::base::RTCStats>>
       StatsMap;
 
-  class ConstIterator {
+  class OWT_EXPORT ConstIterator {
    public:
     ConstIterator(ConstIterator&& other);
     ~ConstIterator();
@@ -208,7 +209,7 @@ class RTCStatsReport {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#certificatestats-dict*
  */
-class RTCCertificateStats : public RTCStats {
+class OWT_EXPORT RTCCertificateStats : public RTCStats {
  public:
   RTCCertificateStats(const std::string& id,
                       int64_t timestamp,
@@ -233,7 +234,7 @@ class RTCCertificateStats : public RTCStats {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#codec-dict*
  */
-class RTCCodecStats final : public RTCStats {
+class OWT_EXPORT RTCCodecStats final : public RTCStats {
  public:
   RTCCodecStats(const std::string& id,
                 int64_t timestamp,
@@ -259,7 +260,7 @@ class RTCCodecStats final : public RTCStats {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#dcstats-dict*
  */
-class RTCDataChannelStats final : public RTCStats {
+class OWT_EXPORT RTCDataChannelStats final : public RTCStats {
  public:
   RTCDataChannelStats(const std::string& id,
                       int64_t timestamp,
@@ -296,7 +297,7 @@ class RTCDataChannelStats final : public RTCStats {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#candidatepair-dict*
  */
-class RTCIceCandidatePairStats final : public RTCStats {
+class OWT_EXPORT RTCIceCandidatePairStats final : public RTCStats {
  public:
   RTCIceCandidatePairStats(const std::string& id,
                            int64_t timestamp,
@@ -378,7 +379,7 @@ class RTCIceCandidatePairStats final : public RTCStats {
 // ice candidate pairs, but there could be candidates not paired with anything.
 // TODO: Add the stats of STUN binding requests (keepalives) and collect
 // them in the new PeerConnection::GetStats.
-class RTCIceCandidateStats : public RTCStats {
+class OWT_EXPORT RTCIceCandidateStats : public RTCStats {
  public:
   RTCIceCandidateStats(const std::string& type,
                        const std::string& id,
@@ -418,7 +419,7 @@ class RTCIceCandidateStats : public RTCStats {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#rtcstatstype-str*
  */
-class RTCLocalIceCandidateStats final : RTCIceCandidateStats {
+class OWT_EXPORT RTCLocalIceCandidateStats final : RTCIceCandidateStats {
  public:
   RTCLocalIceCandidateStats(const std::string& id,
                             int64_t timestamp,
@@ -440,7 +441,7 @@ class RTCLocalIceCandidateStats final : RTCIceCandidateStats {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#rtcstatstype-str*
  */
-class RTCRemoteIceCandidateStats final : public RTCIceCandidateStats {
+class OWT_EXPORT RTCRemoteIceCandidateStats final : public RTCIceCandidateStats {
  public:
   RTCRemoteIceCandidateStats(const std::string& id,
                              int64_t timestamp,
@@ -464,7 +465,7 @@ class RTCRemoteIceCandidateStats final : public RTCIceCandidateStats {
  */
 // Obsoleted due to sender/receiver/transceiver stats being better
 // fits to describe the modern RTCPeerConnection model (unified plan).
-class RTCMediaStreamStats final : public RTCStats {
+class OWT_EXPORT RTCMediaStreamStats final : public RTCStats {
  public:
   RTCMediaStreamStats(const std::string& id,
                       int64_t timestamp,
@@ -483,7 +484,7 @@ class RTCMediaStreamStats final : public RTCStats {
  */
 // This is a combined implementation of RTCInboundRtpStreamStats
 // and RTCOutboundRtpStreamStats.
-class RTCMediaStreamTrackStats final : public RTCStats {
+class OWT_EXPORT RTCMediaStreamTrackStats final : public RTCStats {
  public:
   RTCMediaStreamTrackStats(const std::string& id,
                            int64_t timestamp,
@@ -587,7 +588,7 @@ class RTCMediaStreamTrackStats final : public RTCStats {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#pcstats-dict
  */
-class RTCPeerConnectionStats final : public RTCStats {
+class OWT_EXPORT RTCPeerConnectionStats final : public RTCStats {
  public:
   RTCPeerConnectionStats(const std::string& id,
                          int64_t timestamp,
@@ -604,7 +605,7 @@ class RTCPeerConnectionStats final : public RTCStats {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#streamstats-dict*
  */
-class RTCRTPStreamStats : public RTCStats {
+class OWT_EXPORT RTCRTPStreamStats : public RTCStats {
  public:
   RTCRTPStreamStats(const std::string& type,
                     const std::string& id,
@@ -645,7 +646,7 @@ class RTCRTPStreamStats : public RTCStats {
  * \sa https://w3c.github.io/webrtc-stats/#inboundrtpstats-dict*
  */
 // TODO: Support the remote case |is_remote = true|.
-class RTCInboundRTPStreamStats final : public RTCRTPStreamStats {
+class OWT_EXPORT RTCInboundRTPStreamStats final : public RTCRTPStreamStats {
  public:
   RTCInboundRTPStreamStats(const std::string& id,
                            int64_t timestamp,
@@ -730,7 +731,7 @@ class RTCInboundRTPStreamStats final : public RTCRTPStreamStats {
  * \sa https://w3c.github.io/webrtc-stats/#outboundrtpstats-dict*
  */
 // TODO: Support the remote case |is_remote = true|.
-class RTCOutboundRTPStreamStats final : public RTCRTPStreamStats {
+class OWT_EXPORT RTCOutboundRTPStreamStats final : public RTCRTPStreamStats {
  public:
   RTCOutboundRTPStreamStats(const std::string& id,
                             int64_t timestamp,
@@ -811,7 +812,7 @@ class RTCOutboundRTPStreamStats final : public RTCRTPStreamStats {
 // from RTCReceivedRtpStreamStats and include extra properties including
 // following: localId, roundTripTime, totalRoundTripTime, fractionLost,
 // reportsReceived & roundTripTimeMeasurements.)
-class RTCRemoteInboundRtpStreamStats final : public RTCStats {
+class OWT_EXPORT RTCRemoteInboundRtpStreamStats final : public RTCStats {
  public:
   RTCRemoteInboundRtpStreamStats(const std::string& id,
                                  int64_t timestamp,
@@ -851,7 +852,7 @@ class RTCRemoteInboundRtpStreamStats final : public RTCStats {
 /*!
  * \sa https://w3c.github.io/webrtc-stats/#dom-rtcmediasourcestats
  */
-class RTCMediaSourceStats : public RTCStats {
+class OWT_EXPORT RTCMediaSourceStats : public RTCStats {
  public:
   RTCMediaSourceStats(const std::string& type,
                       const std::string& id,
@@ -868,7 +869,7 @@ class RTCMediaSourceStats : public RTCStats {
 /*!
  * \sa  https://w3c.github.io/webrtc-stats/#dom-rtcaudiosourcestats
  */
-class RTCAudioSourceStats final : public RTCMediaSourceStats {
+class OWT_EXPORT RTCAudioSourceStats final : public RTCMediaSourceStats {
  public:
   RTCAudioSourceStats(const std::string& id,
                       int64_t timestamp,
@@ -888,7 +889,7 @@ class RTCAudioSourceStats final : public RTCMediaSourceStats {
 /*!
  * \sa  https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats
  */
-class RTCVideoSourceStats final : public RTCMediaSourceStats {
+class OWT_EXPORT RTCVideoSourceStats final : public RTCMediaSourceStats {
  public:
   RTCVideoSourceStats(const std::string& id,
                       int64_t timestamp,
@@ -911,7 +912,7 @@ class RTCVideoSourceStats final : public RTCMediaSourceStats {
 /*!
  * \sa  https://w3c.github.io/webrtc-stats/#transportstats-dict*
  */
-class RTCTransportStats final : public RTCStats {
+class OWT_EXPORT RTCTransportStats final : public RTCStats {
  public:
   RTCTransportStats(const std::string& id,
                     int64_t timestamp,
@@ -944,7 +945,7 @@ class RTCTransportStats final : public RTCStats {
 };
 
 /// Define audio sender report
-struct AudioSenderReport {
+struct OWT_EXPORT AudioSenderReport {
   AudioSenderReport(int64_t bytes_sent, int32_t packets_sent,
                     int32_t packets_lost, int64_t round_trip_time, std::string codec_name)
       : bytes_sent(bytes_sent), packets_sent(packets_sent), packets_lost(packets_lost)
@@ -961,7 +962,7 @@ struct AudioSenderReport {
   std::string codec_name;
 };
 /// Define audio receiver report
-struct AudioReceiverReport {
+struct OWT_EXPORT AudioReceiverReport {
   AudioReceiverReport(int64_t bytes_rcvd, int32_t packets_rcvd,
                       int32_t packets_lost, int32_t estimated_delay, std::string codec_name)
       : bytes_rcvd(bytes_rcvd), packets_rcvd(packets_rcvd), packets_lost(packets_lost)
@@ -978,7 +979,7 @@ struct AudioReceiverReport {
   std::string codec_name;
 };
 /// Define video sender report
-struct VideoSenderReport {
+struct OWT_EXPORT VideoSenderReport {
   VideoSenderReport(int64_t bytes_sent, int32_t packets_sent, int32_t packets_lost,
                     int32_t fir_count, int32_t pli_count, int32_t nack_count, int32_t sent_frame_height,
                     int32_t sent_frame_width, int32_t framerate_sent, int32_t last_adapt_reason,
@@ -1023,7 +1024,7 @@ struct VideoSenderReport {
   std::string codec_name;
 };
 /// Define video receiver report
-struct VideoReceiverReport {
+struct OWT_EXPORT VideoReceiverReport {
   VideoReceiverReport(int64_t bytes_rcvd, int32_t packets_rcvd, int32_t packets_lost,
                       int32_t fir_count, int32_t pli_count, int32_t nack_count, int32_t rcvd_frame_height,
                       int32_t rcvd_frame_width, int32_t framerate_rcvd, int32_t framerate_output,
@@ -1059,7 +1060,7 @@ struct VideoReceiverReport {
   int32_t jitter;
 };
 /// Define video bandwidth statistoms
-struct VideoBandwidthStats {
+struct OWT_EXPORT VideoBandwidthStats {
   VideoBandwidthStats() : available_send_bandwidth(0), available_receive_bandwidth(0)
                         , transmit_bitrate(0), retransmit_bitrate(0)
                         , target_encoding_bitrate(0), actual_encoding_bitrate(0) {}
@@ -1077,7 +1078,7 @@ struct VideoBandwidthStats {
   int32_t actual_encoding_bitrate;
 };
 /// Define ICE candidate report
-struct IceCandidateReport {
+struct OWT_EXPORT IceCandidateReport {
   IceCandidateReport(const std::string& id,
                      const std::string& ip,
                      const uint16_t port,
@@ -1105,7 +1106,7 @@ struct IceCandidateReport {
   int32_t priority;
 };
 /// Define ICE candidate pair report.
-struct IceCandidatePairReport {
+struct OWT_EXPORT IceCandidatePairReport {
   IceCandidatePairReport(
       const std::string& id,
       const bool is_active,
@@ -1137,7 +1138,7 @@ typedef std::vector<IceCandidateReportPtr> IceCandidateReports;
 typedef std::shared_ptr<IceCandidatePairReport> IceCandidatePairPtr;
 typedef std::vector<IceCandidatePairPtr> IceCandidatePairReports;
 /// Connection statistoms
-struct ConnectionStats {
+struct OWT_EXPORT ConnectionStats {
   ConnectionStats() {}
   /// Time stamp of connection statistics generation
   std::chrono::system_clock::time_point time_stamp = std::chrono::system_clock::now();

--- a/talk/owt/sdk/include/cpp/owt/base/cursorutils.h
+++ b/talk/owt/sdk/include/cpp/owt/base/cursorutils.h
@@ -5,23 +5,24 @@
 #define OWT_CURSORUTILS_H_
 
 #include <string>
+#include "owt/base/export.h"
 
 namespace owt {
 namespace base {
 
-struct Point {
+struct OWT_EXPORT Point {
   long x;
   long y;
 };
 
-struct CursorRect {
+struct OWT_EXPORT CursorRect {
   long left;
   long top;
   long right;
   long bottom;
 };
 
-struct CursorInfo {
+struct OWT_EXPORT CursorInfo {
   bool visible;
   bool no_shape_update;
   bool colored;
@@ -35,7 +36,7 @@ struct CursorInfo {
   uint8_t* cursor_buffer;
 };
 
-class CursorUtils {
+class OWT_EXPORT CursorUtils {
  public:
 
   // Format is:

--- a/talk/owt/sdk/include/cpp/owt/base/deviceutils.h
+++ b/talk/owt/sdk/include/cpp/owt/base/deviceutils.h
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_DEVICEUTILS_H_
 #define OWT_BASE_DEVICEUTILS_H_
+
 #include <vector>
 #include <string>
 #include "owt/base/commontypes.h"
+
 namespace owt {
 namespace base {
-class DeviceUtils {
+class OWT_EXPORT DeviceUtils {
  public:
   /// Get video capturer IDs.
   static std::vector<std::string> VideoCapturerIds();

--- a/talk/owt/sdk/include/cpp/owt/base/exception.h
+++ b/talk/owt/sdk/include/cpp/owt/base/exception.h
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_EXCEPTION_H_
 #define OWT_BASE_EXCEPTION_H_
+
 #include <string>
+#include "owt/base/export.h"
+
 namespace owt {
 namespace base{
 // TODO: The following exceptions need to sync with other SDKs
@@ -32,7 +35,7 @@ enum class ExceptionType : int {
   kConferenceInvalidSession
 };
 /// Class for exceptions
-class Exception {
+class OWT_EXPORT Exception {
  public:
   /// Default constructor for exceptions.
   Exception();

--- a/talk/owt/sdk/include/cpp/owt/base/export.h
+++ b/talk/owt/sdk/include/cpp/owt/base/export.h
@@ -1,0 +1,35 @@
+// Copyright (C) <2022> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OWT_BASE_EXPORT_H_
+#define OWT_BASE_EXPORT_H_
+
+// OWT_EXPORT is used to mark symbols as exported or imported when OWT is
+// built or used as a shared library.
+// When OWT is built as a static library the RTC_EXPORT macro expands to
+// nothing.
+#ifdef OWT_ENABLE_SYMBOL_EXPORT
+#ifdef WEBRTC_WIN
+
+#ifdef OWT_LIBRARY_IMPL
+#define OWT_EXPORT __declspec(dllexport)
+#else
+#define OWT_EXPORT __declspec(dllimport)
+#endif
+
+#else  // WEBRTC_WIN
+
+#if __has_attribute(visibility) && defined(OWT_LIBRARY_IMPL)
+#define OWT_EXPORT __attribute__((visibility("default")))
+#endif
+
+#endif  // WEBRTC_WIN
+
+#endif  // OWT_ENABLE_SYMBOL_EXPORT
+
+#ifndef OWT_EXPORT
+#define OWT_EXPORT
+#endif
+
+#endif  // OWT_BASE_EXPORT_H_

--- a/talk/owt/sdk/include/cpp/owt/base/framegeneratorinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/framegeneratorinterface.h
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_FRAMEGENERATORINTERFACE_H_
 #define OWT_BASE_FRAMEGENERATORINTERFACE_H_
+
 #include "stdint.h"
+#include "owt/base/export.h"
+
 namespace owt {
 namespace base {
 /**
@@ -11,7 +14,7 @@ namespace base {
  @details Sample rate and channel numbers cannot be changed once the generator is
  created. Currently, only 16 bit little-endian PCM is supported.
 */
-class AudioFrameGeneratorInterface {
+class OWT_EXPORT AudioFrameGeneratorInterface {
  public:
   /**
    @brief Generate frames for next 10ms.
@@ -34,7 +37,7 @@ class AudioFrameGeneratorInterface {
  @brief frame generator interface for users to generates frame.
  FrameGeneratorInterface is the virtual class to implement its own frame generator.
 */
-class VideoFrameGeneratorInterface {
+class OWT_EXPORT VideoFrameGeneratorInterface {
  public:
   enum VideoFrameCodec {
     I420,

--- a/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
+++ b/talk/owt/sdk/include/cpp/owt/base/globalconfiguration.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_GLOBALCONFIGURATION_H_
 #define OWT_BASE_GLOBALCONFIGURATION_H_
+
 #include <memory>
 #include "owt/base/framegeneratorinterface.h"
 #if defined(WEBRTC_WIN) || defined(WEBRTC_LINUX)
@@ -12,12 +13,13 @@
 #include <windows.h>
 #include <d3d11.h>
 #endif
+#include "owt/base/export.h"
 
 namespace owt {
 namespace base {
 /** @cond */
 /// Audio processing settings.
-struct AudioProcessingSettings {
+struct OWT_EXPORT AudioProcessingSettings {
   /**
   @brief Auto echo cancellation enabling/disabling. By default enabled.
   @details If set to true, will enable auto echo cancellation.
@@ -43,7 +45,7 @@ struct AudioProcessingSettings {
 /** @endcond */
 
 /// Port range.
-struct IcePortRange {
+struct OWT_EXPORT IcePortRange {
   /**
    @brief Minimum port number.
   */
@@ -59,7 +61,7 @@ struct IcePortRange {
  GlobalConfiguration class of setting for encoded frame and hardware
  accecleartion configuration.
 */
-class GlobalConfiguration {
+class OWT_EXPORT GlobalConfiguration {
   friend class PeerConnectionDependencyFactory;
 
  public:

--- a/talk/owt/sdk/include/cpp/owt/base/localcamerastreamparameters.h
+++ b/talk/owt/sdk/include/cpp/owt/base/localcamerastreamparameters.h
@@ -14,7 +14,7 @@ namespace base{
   When a stream is created, it will not be impacted if these parameters are
   changed.
 */
-class LocalCameraStreamParameters final {
+class OWT_EXPORT LocalCameraStreamParameters final {
  public:
   /**
     @brief Initialize a LocalCameraStreamParameters.
@@ -78,7 +78,7 @@ class LocalCameraStreamParameters final {
   Currently this only contains an |data_enabled_| field but may be extended
   later to support more settings.
  */
-class LocalDataStreamParameters final {
+class OWT_EXPORT LocalDataStreamParameters final {
  public:
   LocalDataStreamParameters(bool data_enabled) {
     data_enabled_ = data_enabled;
@@ -102,7 +102,7 @@ class LocalDataStreamParameters final {
   When a stream is created, it will not be impacted if these parameters are
   changed.
 */
-class LocalCustomizedStreamParameters final {
+class OWT_EXPORT LocalCustomizedStreamParameters final {
  public:
   /**
     @brief Initialize a LocalCustomizedStreamParameters for YUV input.
@@ -174,7 +174,7 @@ local stream with certain screen or window as source.
 When a stream is created, it will not be impacted if these parameters are
 changed.
 */
-class LocalDesktopStreamParameters final {
+class OWT_EXPORT LocalDesktopStreamParameters final {
  public:
   enum class DesktopCapturePolicy : int {
     /// Default capture policy.

--- a/talk/owt/sdk/include/cpp/owt/base/logging.h
+++ b/talk/owt/sdk/include/cpp/owt/base/logging.h
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_LOGGING_H_
 #define OWT_BASE_LOGGING_H_
+
+#include "owt/base/export.h"
+
 namespace owt {
 namespace base {
 enum class LoggingSeverity : int {
@@ -21,7 +24,7 @@ enum class LoggingSeverity : int {
 };
 /// Logger configuration class. Choose either LogToConsole or LogToFileRotate in
 /// your application for logging to console or file.
-class Logging final {
+class OWT_EXPORT Logging final {
  public:
   /// Set logging severity. All logging messages with higher severity will be
   /// logged.

--- a/talk/owt/sdk/include/cpp/owt/base/mediaconstraints.h
+++ b/talk/owt/sdk/include/cpp/owt/base/mediaconstraints.h
@@ -6,29 +6,29 @@
 #include "owt/base/commontypes.h"
 namespace owt {
 namespace base {
-struct MediaStreamTrackAudioConstraints {
+struct OWT_EXPORT MediaStreamTrackAudioConstraints {
   double volume;
   unsigned long sample_rate;
   unsigned long channel_num;
 };
 
-struct MediaStreamTrackDeviceConstraintsForAudio : MediaStreamTrackAudioConstraints {
+struct OWT_EXPORT MediaStreamTrackDeviceConstraintsForAudio : MediaStreamTrackAudioConstraints {
   std::string device_id;
 };
-struct MediaStreamTrackScreencastConstraintsForAudio : MediaStreamTrackAudioConstraints {
+struct OWT_EXPORT MediaStreamTrackScreencastConstraintsForAudio : MediaStreamTrackAudioConstraints {
   int source_id;  // The handle of the app/desktop
 };
-struct MediaStreamTrackVideoConstraints {
+struct OWT_EXPORT MediaStreamTrackVideoConstraints {
   Resolution resolution;
   double frame_rate;
 };
-struct MediaStreamTrackDeviceConstraintsForVideo : MediaStreamTrackVideoConstraints {
+struct OWT_EXPORT MediaStreamTrackDeviceConstraintsForVideo : MediaStreamTrackVideoConstraints {
   std::string device_id;
 };
-struct MediaStreamTrackScreencastConstraintsForVideo : MediaStreamTrackVideoConstraints {
+struct OWT_EXPORT MediaStreamTrackScreencastConstraintsForVideo : MediaStreamTrackVideoConstraints {
   int source_id;  // The handle of the app/desktop
 };
-struct MediaStreamDeviceConstraints {
+struct OWT_EXPORT MediaStreamDeviceConstraints {
   MediaStreamTrackDeviceConstraintsForAudio audio_track_constraints;
   MediaStreamTrackDeviceConstraintsForVideo video_track_constraints;
 };

--- a/talk/owt/sdk/include/cpp/owt/base/network.h
+++ b/talk/owt/sdk/include/cpp/owt/base/network.h
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_BASE_NETWORK_H_
 #define OWT_BASE_NETWORK_H_
+
+#include "owt/base/export.h"
+
 namespace owt {
 namespace base {
 /// Defines ICE server.
-struct IceServer {
+struct OWT_EXPORT IceServer {
   /// URLs for this group of ICE server.
   std::vector<std::string> urls;
   /// Username.

--- a/talk/owt/sdk/include/cpp/owt/base/options.h
+++ b/talk/owt/sdk/include/cpp/owt/base/options.h
@@ -12,27 +12,27 @@ namespace owt {
 namespace base {
 /// Audio subscription capabilities. Empty means not setting corresponding
 /// capability.
-struct AudioSubscriptionCapabilities {
+struct OWT_EXPORT AudioSubscriptionCapabilities {
   std::vector<AudioCodecParameters> codecs;
 };
 
 /// Video subscription capabilities. Empty means not setting corresponding
 /// capability.
-struct VideoSubscriptionCapabilities {
+struct OWT_EXPORT VideoSubscriptionCapabilities {
   std::vector<VideoCodecParameters> codecs;
   std::vector<Resolution> resolutions;
   std::vector<double> frame_rates;
   std::vector<double> bitrate_multipliers;
   std::vector<unsigned long> keyframe_intervals;
 };
-struct SubscriptionCapabilities {
+struct OWT_EXPORT SubscriptionCapabilities {
   AudioSubscriptionCapabilities audio;
   VideoSubscriptionCapabilities video;
 };
-struct AudioPublicationSettings {
+struct OWT_EXPORT AudioPublicationSettings {
   AudioCodecParameters codec;
 };
-struct VideoPublicationSettings {
+struct OWT_EXPORT VideoPublicationSettings {
   VideoCodecParameters codec;
   Resolution resolution;
   double frame_rate;
@@ -43,13 +43,13 @@ struct VideoPublicationSettings {
 };
 
 #ifdef OWT_ENABLE_QUIC
-struct TransportSettings {
+struct OWT_EXPORT TransportSettings {
   explicit TransportSettings() : transport_type(TransportType::kWebRTC) {}
   TransportType transport_type;
 };
 #endif
 
-struct PublicationSettings {
+struct OWT_EXPORT PublicationSettings {
   std::vector<AudioPublicationSettings> audio;
   std::vector<VideoPublicationSettings> video;
 #ifdef OWT_ENABLE_QUIC
@@ -60,7 +60,7 @@ struct PublicationSettings {
  @brief Publish options describing encoding settings.
  @details Set encoding constraint on video or video using this option.
 */
-struct PublishOptions {
+struct OWT_EXPORT PublishOptions {
   std::vector<AudioEncodingParameters> audio;
   std::vector<VideoEncodingParameters> video;
 #ifdef OWT_ENABLE_QUIC

--- a/talk/owt/sdk/include/cpp/owt/base/publication.h
+++ b/talk/owt/sdk/include/cpp/owt/base/publication.h
@@ -14,7 +14,7 @@
 namespace owt {
 namespace base {
 /// Observer that receives event from publication.
-class PublicationObserver {
+class OWT_EXPORT PublicationObserver {
  public:
   /// Triggered when publication is ended.
   virtual void OnEnded() = 0;
@@ -25,7 +25,7 @@ class PublicationObserver {
   /// Triggered when an error occured on the publication.
   virtual void OnError(std::unique_ptr<Exception> failure) = 0;
 };
-class Publication {
+class OWT_EXPORT Publication {
  public:
   /// Pause current publication's audio or/and video basing on |track_kind| provided.
   virtual void Mute(TrackKind track_kind,

--- a/talk/owt/sdk/include/cpp/owt/base/stream.h
+++ b/talk/owt/sdk/include/cpp/owt/base/stream.h
@@ -48,7 +48,7 @@ class VideoRenderWindow;
 class VideoRendererInterface;
 using webrtc::MediaStreamInterface;
 /// Observer for Stream
-class StreamObserver {
+class OWT_EXPORT StreamObserver {
  public:
   virtual ~StreamObserver() = default;
   /// Triggered when a stream is ended, or the stream is no longer available in
@@ -76,7 +76,7 @@ class WebrtcVideoRendererVaImpl;
 #endif
 
 /// Base class of all streams with media stream
-class Stream {
+class OWT_EXPORT Stream {
   friend class owt::conference::ConferenceClient;
 
  public:
@@ -180,7 +180,7 @@ class Stream {
 /// A QuicStream can be fetched from a published LocalStream for data,
 /// on which you can write to server;
 /// Or from a subscription from server for data, on which you can read.
-class QuicStream : public owt::quic::WebTransportStreamInterface::Visitor {
+class OWT_EXPORT QuicStream : public owt::quic::WebTransportStreamInterface::Visitor {
  public:
   QuicStream(owt::quic::WebTransportStreamInterface* quic_stream,
              const std::string& session_id);
@@ -243,7 +243,7 @@ class QuicStream : public owt::quic::WebTransportStreamInterface::Visitor {
 };
 #endif // OWT_ENABLE_QUIC
 
-class LocalScreenStreamObserver {
+class OWT_EXPORT LocalScreenStreamObserver {
  public:
   /**
   @brief Event callback for local screen stream to request for a source from
@@ -262,7 +262,7 @@ class LocalScreenStreamObserver {
   @brief This class represents a local stream.
   @details A local stream can be published to remote side.
 */
-class LocalStream : public Stream {
+class OWT_EXPORT LocalStream : public Stream {
  public:
 #if !defined(WEBRTC_WIN)
   LocalStream();
@@ -418,7 +418,7 @@ class LocalStream : public Stream {
   @details A remote is published from a remote client or server. Do not construct
   remote stream outside SDK.
 */
-class RemoteStream : public Stream {
+class OWT_EXPORT RemoteStream : public Stream {
   friend class owt::conference::ConferencePeerConnectionChannel;
   friend class owt::conference::ConferenceWebTransportChannel;
   friend class owt::conference::ConferenceClient;

--- a/talk/owt/sdk/include/cpp/owt/base/streamfactory.h
+++ b/talk/owt/sdk/include/cpp/owt/base/streamfactory.h
@@ -4,7 +4,7 @@
 #ifndef OWT_BASE_STREAM_FACTORY_H_
 #define OWT_BASE_STREAM_FACTORY_H_
 #include <unordered_map>
-#inlcude "owt/base/stream.h"
+#include "owt/base/stream.h"
 #include "owt/base/exception.h"
 #include "owt/base/localcamerastreamparameters.h"
 #include "owt/base/macros.h"
@@ -18,7 +18,7 @@ namespace owt {
 namespace base {
 using webrtc::MediaStreamInterface;
 /// Factory class for creating all types of media streams. Not implemented for Windows.
-class StreamFactory {
+class OWT_EXPORT StreamFactory {
  public:
   static std::shared_ptr<LocalStream> CreateLocalStream(MediaStreamDeviceConstraints constraints);
   static std::shared_ptr<LocalStream> CreateLocalStream(MediaStreamScreencastConstraints constraints);

--- a/talk/owt/sdk/include/cpp/owt/base/subscription.h
+++ b/talk/owt/sdk/include/cpp/owt/base/subscription.h
@@ -11,7 +11,7 @@
 namespace owt {
 namespace base {
 /// Observer that receives events from subscription.
-class SubscriptionObserver {
+class OWT_EXPORT SubscriptionObserver {
   public:
     /// Triggered when subscription is ended.
     virtual void OnEnded() = 0;

--- a/talk/owt/sdk/include/cpp/owt/base/videodecoderinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/videodecoderinterface.h
@@ -10,7 +10,7 @@ namespace base {
 /**
  @brief Video encoded frame definition
 */
-struct VideoEncodedFrame {
+struct OWT_EXPORT VideoEncodedFrame {
   /// Encoded frame buffer
   const uint8_t* buffer;
   /// Encoded frame buffer length
@@ -24,7 +24,7 @@ struct VideoEncodedFrame {
  @brief Video decoder interface
  @details Encoded frames will be passed for further customized decoding
 */
-class VideoDecoderInterface {
+class OWT_EXPORT VideoDecoderInterface {
  public:
   /**
    @brief Destructor

--- a/talk/owt/sdk/include/cpp/owt/base/videoencoderinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/videoencoderinterface.h
@@ -20,7 +20,7 @@ enum DecodingTargetIndication {
   kRequired
 };
 
-struct GenericDescriptorInfo {
+struct OWT_EXPORT GenericDescriptorInfo {
   GenericDescriptorInfo()
       : active(false), temporal_id(0), spatial_id(0) {
     std::fill(dependencies.begin(), dependencies.end(), -1);
@@ -41,7 +41,7 @@ struct GenericDescriptorInfo {
   std::array<int, 10> decoding_target_indications;
 };
 
-struct DependencyNotification {
+struct OWT_EXPORT DependencyNotification {
   // The timestamp of the last decodable frame *prior* to the last received.
   uint32_t timestamp_of_last_decodable;
   // The timestamp of the last received frame. It may be undecodable.
@@ -63,7 +63,7 @@ struct DependencyNotification {
   bool last_received_decodable;
 };
 
-struct EncodedImageMetaData {
+struct OWT_EXPORT EncodedImageMetaData {
   // ctor
   EncodedImageMetaData()
       : picture_id(0),
@@ -159,7 +159,7 @@ struct EncodedImageMetaData {
   size_t cursor_data_length = 0;
 };
 
-class EncodedStreamProviderSink {
+class OWT_EXPORT EncodedStreamProviderSink {
  public:
   // Invoked by EncodedStream
   virtual void OnStreamProviderFrame(const std::vector<uint8_t>& buffer,
@@ -167,7 +167,7 @@ class EncodedStreamProviderSink {
 };
 
 // Registered to EncodedStreamProvider to receive events from encoder.
-class EncoderObserver {
+class OWT_EXPORT EncoderObserver {
  public:
   virtual void OnStarted() = 0;
 
@@ -182,7 +182,7 @@ class EncoderObserver {
 };
 
 // Encoder event callback interface
-class EncoderEventCallback {
+class OWT_EXPORT EncoderEventCallback {
  public:
   virtual void StartStreaming() = 0;
 
@@ -198,7 +198,7 @@ class EncoderEventCallback {
 /**
   @brief Encoded stream provider
   */
-class EncodedStreamProvider final
+class OWT_EXPORT EncodedStreamProvider final
     : public std::enable_shared_from_this<EncodedStreamProvider> {
  public:
   static std::shared_ptr<EncodedStreamProvider> Create();
@@ -246,7 +246,7 @@ class EncodedStreamProvider final
   @details Internal webrtc encoder will request from this
    interface when it needs one complete encoded frame.
 */
-class VideoEncoderInterface {
+class OWT_EXPORT VideoEncoderInterface {
  public:
   /**
    @brief Destructor

--- a/talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/base/videorendererinterface.h
@@ -30,14 +30,14 @@ enum class VideoRendererType {
 
 
 #if defined(WEBRTC_WIN)
-struct D3D11ImageHandle {
+struct OWT_EXPORT D3D11ImageHandle {
   ID3D11Device* d3d11_device;
   ID3D11Texture2D* texture;     // The DX texture or texture array.
   int texture_array_index;      // When >=0, indicate the index within texture array 
 };
 #endif
 /// Video buffer and its information
-struct VideoBuffer {
+struct OWT_EXPORT VideoBuffer {
   // TODO: Consider add another field for native handler.
   /// Pointer to video buffer or native handler.
   uint8_t* buffer;
@@ -54,7 +54,7 @@ struct VideoBuffer {
 };
 /// VideoRenderWindow wraps a native Window handle
 #if defined(WEBRTC_WIN)
-class VideoRenderWindow {
+class OWT_EXPORT VideoRenderWindow {
  public:
   VideoRenderWindow() : wnd_(nullptr) {}
   virtual ~VideoRenderWindow() {}
@@ -75,7 +75,7 @@ class VideoRenderWindow {
 
 #if defined(WEBRTC_LINUX)
 #if defined(WEBRTC_USE_X11)
-class VideoRenderWindow {
+class OWT_EXPORT VideoRenderWindow {
  public:
   VideoRenderWindow() : wnd_(0) {}
   virtual ~VideoRenderWindow() {}
@@ -102,7 +102,7 @@ typedef unsigned int VASurfaceID;
 
 /// libva surface that contains a decoded image for rendering on
 /// target window system.
-struct VaSurface {
+struct OWT_EXPORT VaSurface {
   /// va display associated with decoder.
   VADisplay display;
   /// va surface ID.
@@ -123,14 +123,14 @@ struct VaSurface {
 };
 
 /// Video renderer interface for Linux using va based decoding.
-class VideoRendererVaInterface {
+class OWT_EXPORT VideoRendererVaInterface {
  public:
   virtual void RenderFrame(std::unique_ptr<VaSurface> surface) = 0;
   virtual ~VideoRendererVaInterface() {}
 };
 #endif
 /// Interface for rendering VideoFrames in ARGB/I420 format from a VideoTrack.
-class VideoRendererInterface {
+class OWT_EXPORT VideoRendererInterface {
  public:
   /// Passes video buffer to renderer.
   virtual void RenderFrame(std::unique_ptr<VideoBuffer> buffer) {}
@@ -139,13 +139,13 @@ class VideoRendererInterface {
   virtual VideoRendererType Type() = 0;
 };
 #if defined(WEBRTC_WIN)
-struct D3D11Handle {
+struct OWT_EXPORT D3D11Handle {
   ID3D11Texture2D* texture;
   ID3D11Device* d3d11_device;
   ID3D11VideoDevice* d3d11_video_device;
   ID3D11VideoContext* context;
 };
-struct D3D11VAHandle {
+struct OWT_EXPORT D3D11VAHandle {
   ID3D11Texture2D* texture;
   int array_index;
   ID3D11Device* d3d11_device;

--- a/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferenceclient.h
@@ -51,7 +51,7 @@ typedef std::string cert_fingerprint_t;
   Changing this configuration does NOT impact ConferenceClient already
   created.
 */
-struct ConferenceClientConfiguration : public ClientConfiguration {
+struct OWT_EXPORT ConferenceClientConfiguration : public ClientConfiguration {
 #ifdef OWT_ENABLE_QUIC
  public:
   // This function sets trusted server certificate fingerprints for
@@ -68,13 +68,13 @@ class ConferencePeerConnectionChannel;
 #ifdef OWT_ENABLE_QUIC
 class ConferenceWebTransportChannel;
 #endif
-class ConferenceSocketSignalingChannel;
+class OWT_EXPORT ConferenceSocketSignalingChannel;
 /**
   @brief Observer interface for participant
   @details Provides interface for receiving events with regard to the associated
   participant.
 */
-class ParticipantObserver {
+class OWT_EXPORT ParticipantObserver {
   public:
    virtual ~ParticipantObserver() = default;
    /**
@@ -83,7 +83,7 @@ class ParticipantObserver {
    virtual void OnLeft() {}
 };
 /// Participant represents one conference client in a conference room.
-class Participant {
+class OWT_EXPORT Participant {
   friend class ConferenceInfo;
   public:
     Participant(std::string id, std::string role, std::string user_id)
@@ -121,7 +121,7 @@ class Participant {
   @brief Information about the conference.
   @details This information contains current details of the conference.
 */
-class ConferenceInfo {
+class OWT_EXPORT ConferenceInfo {
   friend class ConferenceClient;
   public:
     ConferenceInfo() {}
@@ -168,7 +168,7 @@ class ConferenceInfo {
     std::shared_ptr<Participant> self_;                           // Self participant in the conference.
 };
 /** @cond */
-class ConferenceSocketSignalingChannelObserver {
+class OWT_EXPORT ConferenceSocketSignalingChannelObserver {
  public:
   virtual ~ConferenceSocketSignalingChannelObserver(){}
   virtual void OnUserJoined(std::shared_ptr<sio::message> user) = 0;
@@ -188,7 +188,7 @@ class ConferenceSocketSignalingChannelObserver {
 // ConferencePeerConnectionChannel callback interface.
 // Usually, ConferenceClient should implement these methods and notify
 // application.
-class ConferencePeerConnectionChannelObserver {
+class OWT_EXPORT ConferencePeerConnectionChannelObserver {
  public:
   virtual ~ConferencePeerConnectionChannelObserver(){}
   // Triggered when an unrecoverable error happened. Error may reported by MCU
@@ -199,7 +199,7 @@ class ConferencePeerConnectionChannelObserver {
 };
 #ifdef OWT_ENABLE_QUIC
 // The visitor interface for QuicTransportClientInterface
-class ConferenceWebTransportChannelObserver {
+class OWT_EXPORT ConferenceWebTransportChannelObserver {
  public:
   virtual ~ConferenceWebTransportChannelObserver() = default;
   // Called when connected to a server.
@@ -214,7 +214,7 @@ class ConferenceWebTransportChannelObserver {
 #endif
 /** @endcond */
 /// Observer for OWTConferenceClient.
-class ConferenceClientObserver {
+class OWT_EXPORT ConferenceClientObserver {
  public:
   /**
     @brief Triggers when a stream is added.
@@ -250,7 +250,7 @@ class ConferenceClientObserver {
 };
 
 /// An asynchronous class for app to communicate with a conference in MCU.
-class ConferenceClient final
+class OWT_EXPORT ConferenceClient final
     : ConferenceSocketSignalingChannelObserver,
       ConferencePeerConnectionChannelObserver,
 #ifdef OWT_ENABLE_QUIC

--- a/talk/owt/sdk/include/cpp/owt/conference/conferencepublication.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferencepublication.h
@@ -23,7 +23,7 @@ struct ConnectionStats;
 namespace conference {
 class ConferenceClient;
 using namespace owt::base;
-class ConferencePublication : public Publication, public ConferenceStreamUpdateObserver {
+class OWT_EXPORT ConferencePublication : public Publication, public ConferenceStreamUpdateObserver {
   public:
     ConferencePublication(std::shared_ptr<ConferenceClient> client, const std::string& pub_id,
                           const std::string& stream_id);

--- a/talk/owt/sdk/include/cpp/owt/conference/conferencesubscription.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/conferencesubscription.h
@@ -29,7 +29,7 @@ class QuicTransportStreamInterface;
 namespace conference {
 class ConferenceClient;
 using namespace owt::base;
-class ConferenceSubscription : public ConferenceStreamUpdateObserver,
+class OWT_EXPORT ConferenceSubscription : public ConferenceStreamUpdateObserver,
                                public std::enable_shared_from_this<ConferenceSubscription> {
   public:
     ConferenceSubscription(std::shared_ptr<ConferenceClient> client, const std::string& sub_id,

--- a/talk/owt/sdk/include/cpp/owt/conference/remotemixedstream.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/remotemixedstream.h
@@ -8,13 +8,13 @@
 namespace owt {
 namespace conference {
 /// Observer class for remote mixed stream.
-class RemoteMixedStreamObserver : public owt::base::StreamObserver {
+class OWT_EXPORT RemoteMixedStreamObserver : public owt::base::StreamObserver {
  public:
   virtual void OnVideoLayoutChanged(){}
   virtual void OnActiveInputChanged(const std::string& stream_id){}
 };
 /// This class represent a mixed remote stream.
-class RemoteMixedStream : public owt::base::RemoteStream {
+class OWT_EXPORT RemoteMixedStream : public owt::base::RemoteStream {
  public:
   /** @cond **/
   RemoteMixedStream(const std::string& id,

--- a/talk/owt/sdk/include/cpp/owt/conference/streamupdateobserver.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/streamupdateobserver.h
@@ -11,7 +11,7 @@ namespace owt {
 namespace conference {
 /** @cond */
 /// Observer provided to publication/subscription to report mute/unmute/error/removed event.
-class ConferenceStreamUpdateObserver {
+class OWT_EXPORT ConferenceStreamUpdateObserver {
 public:
   /**
   @brief Triggers when audio or video status switched between active/inactive.

--- a/talk/owt/sdk/include/cpp/owt/conference/subscribeoptions.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/subscribeoptions.h
@@ -8,7 +8,7 @@
 namespace owt {
 namespace conference {
 /// Audio subscription contraints.
-struct AudioSubscriptionConstraints {
+struct OWT_EXPORT AudioSubscriptionConstraints {
   /**
    @brief Construct AudioSubcriptionConstraints with defaut settings.
    @details By default the audio suscription is enabled.
@@ -19,7 +19,7 @@ struct AudioSubscriptionConstraints {
   std::vector<owt::base::AudioCodecParameters> codecs;
 };
 /// Video subscription constraints.
-struct VideoSubscriptionConstraints {
+struct OWT_EXPORT VideoSubscriptionConstraints {
   /**
    @brief Construct VideoSubscriptionConstraints with default values.
    @details By default the publication settings of stream is used.
@@ -43,14 +43,14 @@ struct VideoSubscriptionConstraints {
 
 #ifdef OWT_ENABLE_QUIC
 /// Data subscription constraints.
-struct DataSubscriptionConstraints {
+struct OWT_EXPORT DataSubscriptionConstraints {
   explicit DataSubscriptionConstraints() : enabled(false) {}
   bool enabled;
 };
 #endif
 
 /// Subscribe options
-struct SubscribeOptions {
+struct OWT_EXPORT SubscribeOptions {
   AudioSubscriptionConstraints audio;
   VideoSubscriptionConstraints video;
 #ifdef OWT_ENABLE_QUIC
@@ -59,7 +59,7 @@ struct SubscribeOptions {
 };
 /// Video subscription update constrains used by subscription's ApplyOptions
 /// API.
-struct VideoSubscriptionUpdateConstraints {
+struct OWT_EXPORT VideoSubscriptionUpdateConstraints {
   /**
    @brief Construct VideoSubscriptionUpdateConstraints with default value.
    */
@@ -74,7 +74,7 @@ struct VideoSubscriptionUpdateConstraints {
   unsigned long keyFrameInterval;
 };
 /// Subscription update option used by subscription's ApplyOptions API.
-struct SubscriptionUpdateOptions {
+struct OWT_EXPORT SubscriptionUpdateOptions {
   /// Options for updating a subscription.
   VideoSubscriptionUpdateConstraints video;
 };

--- a/talk/owt/sdk/include/cpp/owt/conference/user.h
+++ b/talk/owt/sdk/include/cpp/owt/conference/user.h
@@ -4,10 +4,11 @@
 #ifndef OWT_CONFERENCE_USER_H_
 #define OWT_CONFERENCE_USER_H_
 #include <string>
+#include "owt/base/export.h"
 namespace owt {
 namespace conference {
 /// This class represent a user's permission.
-class Permission {
+class OWT_EXPORT Permission {
  public:
   /** @cond */
   Permission(bool publish, bool subscribe, bool record)
@@ -25,7 +26,7 @@ class Permission {
   bool subscribe_;
 };
 /// This class represent an attendee of a conference, replaced by Participant class
-class User {
+class OWT_EXPORT User {
  public:
   User(std::string id,
        std::string name,

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2pclient.h
@@ -13,6 +13,7 @@
 #include "owt/base/connectionstats.h"
 #include "owt/base/macros.h"
 #include "owt/base/stream.h"
+#include "owt/base/export.h"
 #include "owt/p2p/p2ppublication.h"
 #include "owt/p2p/p2psignalingchannelinterface.h"
 #include "owt/p2p/p2psignalingsenderinterface.h"
@@ -34,14 +35,14 @@ class P2PPeerConnectionChannelObserver;
  This configuration is used while creating P2PClient. Changing this
  configuration does NOT impact P2PClient already created.
 */
-struct P2PClientConfiguration : owt::base::ClientConfiguration {
+struct OWT_EXPORT P2PClientConfiguration : owt::base::ClientConfiguration {
   std::vector<AudioEncodingParameters> audio_encodings;
   std::vector<VideoEncodingParameters> video_encodings;
 };
 class P2PPeerConnectionChannelObserverCppImpl;
 class P2PPeerConnectionChannel;
 /// Observer for P2PClient
-class P2PClientObserver {
+class OWT_EXPORT P2PClientObserver {
  public:
   virtual ~P2PClientObserver() = default;
   /**
@@ -64,7 +65,7 @@ class P2PClientObserver {
   virtual void OnServerDisconnected(){}
 };
 /// An async client for P2P WebRTC sessions
-class P2PClient final
+class OWT_EXPORT P2PClient final
     : public P2PSignalingSenderInterface,
       public P2PSignalingChannelObserver,
       public std::enable_shared_from_this<P2PClient> {

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2ppublication.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2ppublication.h
@@ -16,7 +16,7 @@ namespace owt {
 namespace p2p {
 using namespace owt::base;
 class P2PClient;
-class P2PPublication : public Publication {
+class OWT_EXPORT P2PPublication : public Publication {
  public:
   P2PPublication(std::shared_ptr<P2PClient> client, std::string target_id, std::shared_ptr<LocalStream> stream);
   virtual ~P2PPublication() {}

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2psignalingchannelinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2psignalingchannelinterface.h
@@ -14,8 +14,9 @@ using namespace owt::base;
 /**
  @brief Signaling channel will notify observer when event triggers.
  */
-class P2PSignalingChannelObserver {
+class OWT_EXPORT P2PSignalingChannelObserver {
  public:
+  virtual ~P2PSignalingChannelObserver() = default;
   /**
    @brief This function will be triggered when new message arrives.
    @param message Message received from signaling server.
@@ -32,7 +33,7 @@ class P2PSignalingChannelObserver {
  @brief Protocol for signaling channel.
  Developers may utilize their own signaling server by implmenting this protocol.
  */
-class P2PSignalingChannelInterface {
+class OWT_EXPORT P2PSignalingChannelInterface {
  public:
   virtual ~P2PSignalingChannelInterface() = default;
   /**

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2psignalingreceiverinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2psignalingreceiverinterface.h
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #ifndef OWT_P2P_SIGNALINGRECEIVERINTERFACE_H_
 #define OWT_P2P_SIGNALINGRECEIVERINTERFACE_H_
+
+#include "owt/base/export.h"
+
 namespace owt {
 namespace p2p {
 /** @cond */
@@ -11,7 +14,7 @@ namespace p2p {
   @details The receiver may be a peerconnection instance which can deal with the
   message received.
 */
-class P2PSignalingReceiverInterface {
+class OWT_EXPORT P2PSignalingReceiverInterface {
  public:
   /// Received signaling message.
   virtual void OnIncomingSignalingMessage(const std::string& message) = 0;

--- a/talk/owt/sdk/include/cpp/owt/p2p/p2psignalingsenderinterface.h
+++ b/talk/owt/sdk/include/cpp/owt/p2p/p2psignalingsenderinterface.h
@@ -15,7 +15,7 @@ namespace p2p {
   @details The sender may be a PeerClient/ConferenceClient instance which can
   send out signaling messages created from peerconnection.
 */
-class P2PSignalingSenderInterface {
+class OWT_EXPORT P2PSignalingSenderInterface {
  public:
   virtual ~P2PSignalingSenderInterface() {}
   /// Send a signaling message.


### PR DESCRIPTION
This change allows OWT SDK to be built as a shared library.