### PR TITLE
Add CustomizedOutputAudioDeviceModule.

### DIFF
--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -123,6 +123,8 @@ static_library("owt_sdk_base") {
     "sdk/base/customizedaudiocapturer.h",
     "sdk/base/customizedaudiodevicemodule.cc",
     "sdk/base/customizedaudiodevicemodule.h",
+    "sdk/base/customizedoutputaudiodevicemodule.cc",
+    "sdk/base/customizedoutputaudiodevicemodule.h",
     "sdk/base/deviceutils.cc",
     "sdk/base/encodedstreamproviderwrapper.cc",
     "sdk/base/encodedstreamproviderwrapper.h",

--- a/talk/owt/sdk/base/customizedaudiodevicemodule.cc
+++ b/talk/owt/sdk/base/customizedaudiodevicemodule.cc
@@ -10,6 +10,7 @@
 
 #include "talk/owt/sdk/base/customizedaudiodevicemodule.h"
 #include "talk/owt/sdk/base/customizedaudiocapturer.h"
+#include "talk/owt/sdk/base/customizedoutputaudiodevicemodule.h"
 #include "webrtc/api/make_ref_counted.h"
 #include "webrtc/common_audio/signal_processing/include/signal_processing_library.h"
 #include "webrtc/modules/audio_device/audio_device_config.h"
@@ -597,8 +598,8 @@ void CustomizedAudioDeviceModule::CreateOutputAdm() {
     _outputAdm = webrtc::AudioDeviceModuleImpl::Create(
         AudioDeviceModule::kPlatformDefaultAudio, task_queue_factory_.get());
 #else
-    _outputAdm = rtc::scoped_refptr<webrtc::FakeAudioDeviceModule>(
-        new rtc::RefCountedObject<webrtc::FakeAudioDeviceModule>());
+    _outputAdm = rtc::scoped_refptr<CustomizedOutputAudioDeviceModule>(
+        new rtc::RefCountedObject<CustomizedOutputAudioDeviceModule>());
 #endif
   }
 }

--- a/talk/owt/sdk/base/customizedoutputaudiodevicemodule.cc
+++ b/talk/owt/sdk/base/customizedoutputaudiodevicemodule.cc
@@ -1,0 +1,107 @@
+// Copyright (C) <2023> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "talk/owt/sdk/base/customizedoutputaudiodevicemodule.h"
+#include "rtc_base/platform_thread.h"
+#include "third_party/webrtc/api/task_queue/default_task_queue_factory.h"
+#include "third_party/webrtc/rtc_base/time_utils.h"
+#include "third_party/webrtc/system_wrappers/include/sleep.h"
+
+namespace owt {
+namespace base {
+CustomizedOutputAudioDeviceModule::CustomizedOutputAudioDeviceModule()
+    : task_queue_factory_(webrtc::CreateDefaultTaskQueueFactory()),
+      audio_device_buffer_(
+          new webrtc::AudioDeviceBuffer(task_queue_factory_.get())),
+      playout_frames_in_10ms_(48000 / 100) {}
+
+int32_t CustomizedOutputAudioDeviceModule::RegisterAudioCallback(
+    webrtc::AudioTransport* audioCallback) {
+  return audio_device_buffer_->RegisterAudioCallback(audioCallback);
+}
+
+int32_t CustomizedOutputAudioDeviceModule::StopPlayout() {
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    playing_ = false;
+  }
+  if (play_thread_.get()) {
+    play_thread_->Finalize();
+    play_thread_.reset();
+  }
+  return 0;
+}
+
+int32_t CustomizedOutputAudioDeviceModule::PlayoutIsAvailable(bool* available) {
+  *available = true;
+  return 0;
+}
+
+int32_t CustomizedOutputAudioDeviceModule::InitPlayout() {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (audio_device_buffer_.get()) {
+    audio_device_buffer_->SetPlayoutSampleRate(48000);
+    audio_device_buffer_->SetPlayoutChannels(2);
+  }
+  return 0;
+}
+
+bool CustomizedOutputAudioDeviceModule::PlayThreadProcess() {
+  if (!playing_)
+    return false;
+  int64_t current_time = rtc::TimeMillis();
+
+  mutex_.lock();
+  if (last_call_millis_ == 0 || current_time - last_call_millis_ >= 10) {
+    mutex_.unlock();
+    audio_device_buffer_->RequestPlayoutData(playout_frames_in_10ms_);
+    mutex_.lock();
+    last_call_millis_ = current_time;
+  }
+  mutex_.unlock();
+  int64_t delta_time = rtc::TimeMillis() - current_time;
+  if (delta_time < 10) {
+    webrtc::SleepMs(10 - delta_time);
+  }
+  return true;
+}
+
+int32_t CustomizedOutputAudioDeviceModule::StartPlayout() {
+  if (playing_)
+    return 0;
+
+  playing_ = true;
+  play_thread_ =
+      std::make_unique<rtc::PlatformThread>(rtc::PlatformThread::SpawnJoinable(
+          [this] {
+            while (PlayThreadProcess()) {
+            }
+          },
+          "fake_audio_play_thread",
+          rtc::ThreadAttributes().SetPriority(rtc::ThreadPriority::kRealtime)));
+  return 0;
+}
+
+bool CustomizedOutputAudioDeviceModule::Playing() const {
+  return playing_;
+}
+
+bool CustomizedOutputAudioDeviceModule::Recording() const {
+  return true;
+}
+
+int32_t CustomizedOutputAudioDeviceModule::StereoPlayoutIsAvailable(
+    bool* available) const {
+  *available = true;
+  return 0;
+}
+
+int32_t CustomizedOutputAudioDeviceModule::StereoRecordingIsAvailable(
+    bool* available) const {
+  *available = true;
+  return 0;
+}
+
+}  // namespace base
+}  // namespace owt

--- a/talk/owt/sdk/base/customizedoutputaudiodevicemodule.h
+++ b/talk/owt/sdk/base/customizedoutputaudiodevicemodule.h
@@ -1,0 +1,42 @@
+// Copyright (C) <2023> Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OWT_BASE_CUSTOMIZEDOUTPUTAUDIODEVICEMODULE_H_
+#define OWT_BASE_CUSTOMIZEDOUTPUTAUDIODEVICEMODULE_H_
+
+#include <mutex>
+#include "third_party/webrtc/modules/audio_device/audio_device_buffer.h"
+#include "third_party/webrtc/modules/audio_device/include/fake_audio_device.h"
+#include "third_party/webrtc/rtc_base/platform_thread.h"
+
+namespace owt {
+namespace base {
+class CustomizedOutputAudioDeviceModule : public webrtc::FakeAudioDeviceModule {
+ public:
+  CustomizedOutputAudioDeviceModule();
+  int32_t RegisterAudioCallback(webrtc::AudioTransport* audioCallback) override;
+  int32_t StopPlayout() override;
+  int32_t PlayoutIsAvailable(bool* available) override;
+  int32_t InitPlayout() override;
+  int32_t StartPlayout() override;
+  bool Playing() const override;
+  bool Recording() const override;
+  int32_t StereoPlayoutIsAvailable(bool* available) const override;
+  int32_t StereoRecordingIsAvailable(bool* available) const override;
+
+ private:
+  bool PlayThreadProcess();
+
+  std::unique_ptr<webrtc::TaskQueueFactory> task_queue_factory_;
+  std::unique_ptr<webrtc::AudioDeviceBuffer> audio_device_buffer_;
+  std::unique_ptr<rtc::PlatformThread> play_thread_;
+  size_t playout_frames_in_10ms_;
+  bool playing_ = false;
+  int64_t last_call_millis_ = 0;
+  std::mutex mutex_;
+};
+}  // namespace base
+}  // namespace owt
+
+#endif


### PR DESCRIPTION
This allows audio data received to be routed to implementations of AudioPlayerInterface without depending on platform audio module.