### PR TITLE
Disable thin archive for OWT SDK static lib on Linux.

### DIFF
--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -116,6 +116,7 @@ if (!is_ios) {
         deps += [ ":owt_sdk_conf" ]
       }
       complete_static_lib = true
+      configs -= [ "//build/config/compiler:thin_archive" ]
     }
   }
 }


### PR DESCRIPTION
libowt.a is expected to be a complete static lib.