### PR TITLE
Define GN arg owt_ffmpeg_root for the whole project.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -98,7 +98,7 @@ deps = {
     Var('chromium_git') + '/chromium/src/third_party' + '@' + 'cd30703e732f3436f72f63c13f16ebb19803ddd6',
   # WebRTC-only dependencies (not present in Chromium).
   'src/third_party/webrtc':
-    Var('deps_owt_git') + '/owt-deps-webrtc' + '@' + 'c34716479181dfaac4635098422ed3914d9555c3',
+    Var('deps_owt_git') + '/owt-deps-webrtc' + '@' + 'f276236c868a52daa18496d619322c349e4b2b49',
   # Gradle 4.3-rc4. Used for testing Android Studio project generation for WebRTC.
   'src/third_party/webrtc/examples/androidtests/third_party/gradle': {
     'url': Var('chromium_git') + '/external/github.com/gradle/gradle.git' + '@' +

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -69,7 +69,15 @@ declare_args() {
   # Enable HEVC for WebRTC.
   rtc_use_h265 = false
 
-  # Build OWT for cloud gaming. It enables low latency features, and disables audio processing for server side. It may break normal WebRTC features, is not intended for general use.
+  # Build OWT for cloud gaming. It enables low latency features, and disables
+  # audio processing for server side. It may break normal WebRTC features, and
+  # is not intended for general use.
   owt_cg_server = false
   owt_cg_client = false
+
+  # Path to to root directory of FFmpeg, with headers in include sub-folder, and
+  # libs in lib sub-folder. Binary libraries are not necessary for building OWT
+  # SDK, but it is needed by your application or tests when this argument is
+  # specified. If the value is an empty string, FFMPEG will not be used.
+  owt_ffmpeg_root = ""
 }

--- a/scripts/build-win.py
+++ b/scripts/build-win.py
@@ -94,7 +94,7 @@ def gngen(arch, sio_root, ffmpeg_root, ssl_root, msdk_root, quic_root, scheme, t
         # If sio_root is not specified, conference SDK is not able to build.
         gn_args.append('owt_sio_header_root="%s"' % (sio_root + r'\include'))
     if ffmpeg_root:
-        gn_args.append('owt_ffmpeg_header_root="%s"'%(ffmpeg_root+r'\include'))
+        gn_args.append('owt_ffmpeg_root="%s"'%(ffmpeg_root))
     if ffmpeg_root or msdk_root or cg_server:
         gn_args.append('rtc_use_h264=true')
     if msdk_root or cg_server:

--- a/scripts/build_linux.py
+++ b/scripts/build_linux.py
@@ -94,7 +94,7 @@ def gngen(arch, sio_root, ffmpeg_root, ssl_root, msdk_root, quic_root, scheme, t
     else:
         gn_args.extend(['enable_libaom=true'])
     if ffmpeg_root:
-        gn_args.append('owt_ffmpeg_header_root="%s"'%(ffmpeg_root+'/include'))
+        gn_args.append('owt_ffmpeg_root="%s"'%(ffmpeg_root))
     if ffmpeg_root or msdk_root or cg_server:
         gn_args.append('rtc_use_h264=true')
     if msdk_root or cg_server:

--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -12,7 +12,6 @@ declare_args() {
   owt_msdk_lib_root = ""
   owt_msdk_header_root = ""
   owt_sio_header_root = ""
-  owt_ffmpeg_header_root = ""
 }
 
 # Introduced for using libvpx config files. We only enable libvpx rate
@@ -236,8 +235,8 @@ static_library("owt_sdk_base") {
     defines += [ "WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE" ]
   }
 
-  if (owt_ffmpeg_header_root != "") {
-    include_dirs += [ owt_ffmpeg_header_root ]
+  if (owt_ffmpeg_root != "") {
+    include_dirs += [ owt_ffmpeg_root + "/include" ]
   }
 
   if (rtc_use_x11) {
@@ -354,7 +353,7 @@ static_library("owt_sdk_base") {
     ]
   }
 
-  if (owt_ffmpeg_header_root != "") {
+  if (owt_ffmpeg_root != "") {
     if (is_win) {
       sources += [
         "sdk/base/win/d3d11va_h264_decoder.cc",


### PR DESCRIPTION
This changes allows third_party/webrtc access owt_ffmpeg_root as well. So external headers will be included when it's defined.