### PR TITLE
Ignore rejected m= sections

### DIFF
--- a/talk/owt/sdk/base/sdputils.cc
+++ b/talk/owt/sdk/base/sdputils.cc
@@ -256,6 +256,10 @@ std::string SdpUtils::SetPreferCodecs(const std::string& sdp,
       RTC_LOG(LS_WARNING) << "Wrong SDP format description: " << m_line;
       return sdp;
     }
+    if (m_line_vector[1] == "0") {
+      RTC_LOG(LS_WARNING) << "Ignore rejected section: " << m_line;
+      return sdp;
+    }
     std::stringstream m_line_stream;
     for (int i = 0; i < 3; i++) {
       if (i < 2)


### PR DESCRIPTION
m=section could be rejected because of no match codecs. In this case, munging SDP here may result media format description to be empty.