### PR TITLE
CG build claims to support all codecs.

### DIFF
--- a/talk/owt/BUILD.gn
+++ b/talk/owt/BUILD.gn
@@ -227,6 +227,13 @@ static_library("owt_sdk_base") {
 
   defines = [ "USE_BUILTIN_SW_CODECS" ]
 
+  if (owt_cg_server) {
+    defines += [ "OWT_CG_SERVER" ]
+  }
+  if (owt_cg_client) {
+    defines += [ "OWT_CG_CLIENT" ]
+  }
+
   if (owt_msdk_header_root != "") {
     include_dirs += [ owt_msdk_header_root ]
   }
@@ -295,7 +302,7 @@ static_library("owt_sdk_base") {
       "sdk/base/win/videorendererd3d11.cc",
       "sdk/base/win/videorendererd3d11.h",
     ]
-    if (owt_msdk_header_root != "" || owt_ffmpeg_root != "") {
+    if (owt_msdk_header_root != "" || owt_ffmpeg_root != ""||owt_cg_server) {
       sources += [
         "sdk/base/win/externalvideodecoderfactory.cc",
         "sdk/base/win/externalvideodecoderfactory.h",
@@ -419,6 +426,9 @@ static_library("owt_sdk_p2p") {
   configs += [ ":owt_common" ]
   if (owt_cg_server) {
     defines = [ "OWT_CG_SERVER" ]
+  }
+  if (owt_cg_client) {
+    defines = [ "OWT_CG_CLIENT" ]
   }
 }
 static_library("owt_sdk_conf") {

--- a/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
+++ b/talk/owt/sdk/base/peerconnectiondependencyfactory.cc
@@ -190,7 +190,11 @@ void PeerConnectionDependencyFactory::
   if (encoded_frame_) {
     encoder_factory.reset(new EncodedVideoEncoderFactory());
   } else if (render_hardware_acceleration_enabled_) {
-#if defined(WEBRTC_WIN) && defined(OWT_USE_MSDK)
+#if defined(OWT_CG_CLIENT)
+    // CG client app takes care of external encoder. If it's expected to receive
+    // video streams, an encoder must be provided.
+    encoder_factory.reset(new ExternalVideoEncoderFactory());
+#elif defined(WEBRTC_WIN) && defined(OWT_USE_MSDK)
     encoder_factory.reset(new ExternalVideoEncoderFactory());
 #else
     // For Linux HW encoder pending verification.
@@ -204,10 +208,12 @@ void PeerConnectionDependencyFactory::
     decoder_factory.reset(new CustomizedVideoDecoderFactory(
         GlobalConfiguration::GetCustomizedVideoDecoder()));
   } else if (render_hardware_acceleration_enabled_) {
-#if defined(OWT_USE_MSDK) || defined(OWT_USE_FFMPEG)
+#if defined(OWT_USE_MSDK) || defined(OWT_USE_FFMPEG) || defined(OWT_CG_SERVER)
 #if defined(WEBRTC_WIN)
     decoder_factory.reset(new ExternalVideoDecoderFactory(nullptr));
-#else
+#elif !defined(OWT_CG_SERVER)
+    // Linux CG server is supposed to have external decoder so it can receives
+    // video streams from client.
     decoder_factory.reset(new ExternalVideoDecoderFactory());
 #endif
 #else


### PR DESCRIPTION
This is a workaround for CG build. As CG server always uses encoded video input, WebRTC cannot select codecs based on negotiation. It is assumed CG apps take care of actual codecs.