### PR TITLE
logging: use static stream in LogToFileRotate

### DIFF
--- a/talk/owt/sdk/base/logging.cc
+++ b/talk/owt/sdk/base/logging.cc
@@ -37,7 +37,7 @@ void Logging::LogToConsole(LoggingSeverity severity) {
 }
 void Logging::LogToFileRotate(LoggingSeverity severity, std::string& dir, size_t max_log_size) {
   min_severity_ = severity;
-  std::shared_ptr<rtc::CallSessionFileRotatingLogSink> log_sink =
+  static std::shared_ptr<rtc::CallSessionFileRotatingLogSink> log_sink =
       std::make_shared<rtc::CallSessionFileRotatingLogSink>(dir, max_log_size);
   log_sink->Init();
   rtc::LogMessage::AddLogToStream(log_sink.get(), logging_severity_map[static_cast<int>(severity)]);


### PR DESCRIPTION
We initialized the stream to write to in LogToFileRotate() but it got deinitialized on the exit from the scope while its reference remained in the logging which causes a crash on the first write. That's a quick fix. More appropriately would be to change webrtc function prototype for it to accept stream for the ref count increment.