### PR TITLE
D3D11 decoder supports getting side data from HEVC streams.

### DIFF
--- a/talk/owt/sdk/base/customizedvideoencoderproxy.cc
+++ b/talk/owt/sdk/base/customizedvideoencoderproxy.cc
@@ -195,7 +195,7 @@ int32_t CustomizedVideoEncoderProxy::Encode(
               (cursor_data_ptr && cursor_data_size))) {
     data_ptr[0] = data_ptr[1] = data_ptr[2] = 0;
     data_ptr[3] = 0x01;                 // start code: byte 0-3
-    data_ptr[4] = 0x27;                 // F: 0, nal_unit_type: prefix-SEI
+    data_ptr[4] = 0x4e;                 // F: 0, nal_unit_type: prefix-SEI
     data_ptr[5] = 0x1;                  // layerID: 0; TID: 1
     data_ptr[6] = 0x05;                 // userdata unregistered
     data_ptr[7] = 16 + side_data_size;  // payload size

--- a/talk/owt/sdk/base/win/d3d11_video_decoder.h
+++ b/talk/owt/sdk/base/win/d3d11_video_decoder.h
@@ -77,6 +77,7 @@ class D3D11VideoDecoder : public webrtc::VideoDecoder {
   CComPtr<ID3D11VideoContext> d3d11_video_context_;
   CComQIPtr<IDXGIAdapter> m_padapter_;
   CComPtr<IDXGIFactory2> m_pdxgi_factory_;
+  Settings settings_;
   std::unique_ptr<D3D11VAHandle> surface_handle_;
   std::vector<uint8_t> current_side_data_;
   std::unordered_map<uint32_t, std::vector<uint8_t>> side_data_list_;


### PR DESCRIPTION
The implementation is picked from MSDK video decoder.