### PR TITLE
Add OWT API to support rotating log to file with specified prefix.

### DIFF
--- a/talk/owt/sdk/base/logging.cc
+++ b/talk/owt/sdk/base/logging.cc
@@ -35,6 +35,7 @@ void Logging::LogToConsole(LoggingSeverity severity) {
   min_severity_ = severity;
   rtc::LogMessage::ConfigureLogging(logging_param_map[static_cast<int>(severity)].c_str());
 }
+
 void Logging::LogToFileRotate(LoggingSeverity severity, std::string& dir, size_t max_log_size) {
   min_severity_ = severity;
   static std::shared_ptr<rtc::CallSessionFileRotatingLogSink> log_sink =
@@ -42,6 +43,20 @@ void Logging::LogToFileRotate(LoggingSeverity severity, std::string& dir, size_t
   log_sink->Init();
   rtc::LogMessage::AddLogToStream(log_sink.get(), logging_severity_map[static_cast<int>(severity)]);
 }
+
+void Logging::LogToFileRotate(LoggingSeverity severity,
+                              const std::string& dir,
+                              const std::string& prefix,
+                              size_t max_log_size) {
+  min_severity_ = severity;
+  static std::shared_ptr<rtc::CallSessionFileRotatingLogSink> log_sink =
+      std::make_shared<rtc::CallSessionFileRotatingLogSink>(dir, prefix,
+                                                            max_log_size);
+  log_sink->Init();
+  rtc::LogMessage::AddLogToStream(
+      log_sink.get(), logging_severity_map[static_cast<int>(severity)]);
+}
+
 LoggingSeverity Logging::Severity() {
   return min_severity_;
 }

--- a/talk/owt/sdk/include/cpp/owt/base/logging.h
+++ b/talk/owt/sdk/include/cpp/owt/base/logging.h
@@ -35,6 +35,13 @@ class OWT_EXPORT Logging final {
   static void LogToConsole(LoggingSeverity severity);
   /// Set logging to files under provided dir rotately.
   static void LogToFileRotate(LoggingSeverity severity, std::string& dir, size_t max_log_size);
+  /// Set logging to files under provided dir rotately, with file name starting
+  /// with the 'prefix`.
+  static void LogToFileRotate(LoggingSeverity severity,
+                              const std::string& dir,
+                              const std::string& prefix,
+                              size_t max_log_size);
+
  private:
   static LoggingSeverity min_severity_;
 };


### PR DESCRIPTION
This is to work with https://github.com/open-webrtc-toolkit/owt-deps-webrtc/pull/202 to support rotating log to file with prefix specified by application.